### PR TITLE
fix(convex): generatePlan auth + replace filter() with compound indexes

### DIFF
--- a/convex/ai.js
+++ b/convex/ai.js
@@ -48,21 +48,21 @@ export const generatePlan = action({
     regenerate: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    // Prefer the authenticated caller; fall back to the explicit userId
-    // arg so the existing onboarding flow (which passes viewer._id)
-    // keeps working unchanged. We resolve auth via a sibling query so
-    // the Node action doesn't need to import @convex-dev/auth directly.
+    // Identity is always derived server-side from the Convex auth context
+    // via a sibling query (the Node runtime can't import @convex-dev/auth
+    // directly). `args.userId` is kept for backwards compat with the
+    // onboarding flow but is only accepted when it matches the authed id —
+    // never as a fallback, so an unauthenticated caller cannot name a
+    // victim's id and ride the KB/onboarding reads below.
     const authUserId = await ctx.runQuery(
       api.planMutations.getAuthenticatedUserId,
       {}
     );
-    const userId = authUserId || args.userId;
-    if (!userId) throw new Error("Not authenticated");
-    // If the arg was passed explicitly and doesn't match auth, refuse —
-    // prevents a client from triggering generation for someone else.
-    if (authUserId && args.userId && authUserId !== args.userId) {
+    if (!authUserId) throw new Error("Not authenticated");
+    if (args.userId && args.userId !== authUserId) {
       throw new Error("Not authorized");
     }
+    const userId = authUserId;
 
     const regenerate = args.regenerate === true;
 

--- a/convex/plans.js
+++ b/convex/plans.js
@@ -144,14 +144,16 @@ export const getSharedWeekActivities = query({
 
     const week = await ctx.db
       .query("weeks")
-      .withIndex("by_plan", (q) => q.eq("planId", plan._id))
-      .filter((q) => q.eq(q.field("number"), args.weekNumber))
+      .withIndex("by_plan_number", (q) =>
+        q.eq("planId", plan._id).eq("number", args.weekNumber)
+      )
       .first();
 
     const activities = await ctx.db
       .query("activities")
-      .withIndex("by_plan", (q) => q.eq("planId", plan._id))
-      .filter((q) => q.eq(q.field("weekNumber"), args.weekNumber))
+      .withIndex("by_plan_week", (q) =>
+        q.eq("planId", plan._id).eq("weekNumber", args.weekNumber)
+      )
       .collect();
 
     return {

--- a/convex/reflections.js
+++ b/convex/reflections.js
@@ -213,8 +213,9 @@ export const getActivitiesForWeekInternal = internalQuery({
   handler: async (ctx, { userId, weekNumber }) => {
     return await ctx.db
       .query("activities")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
-      .filter((q) => q.eq(q.field("weekNumber"), weekNumber))
+      .withIndex("by_user_week", (q) =>
+        q.eq("userId", userId).eq("weekNumber", weekNumber)
+      )
       .collect();
   },
 });

--- a/convex/schema.js
+++ b/convex/schema.js
@@ -95,7 +95,8 @@ export default defineSchema({
   })
     .index("by_plan", ["planId"])
     .index("by_phase", ["phaseId"])
-    .index("by_user_number", ["userId", "number"]),
+    .index("by_user_number", ["userId", "number"])
+    .index("by_plan_number", ["planId", "number"]),
 
   activities: defineTable({
     planId: v.id("plans"),
@@ -123,7 +124,9 @@ export default defineSchema({
     .index("by_user_status", ["userId", "status"])
     .index("by_user_date", ["userId", "scheduledDate"])
     .index("by_week", ["weekId"])
-    .index("by_plan", ["planId"]),
+    .index("by_plan", ["planId"])
+    .index("by_plan_week", ["planId", "weekNumber"])
+    .index("by_user_week", ["userId", "weekNumber"]),
 
   goals: defineTable({
     userId: v.id("users"),


### PR DESCRIPTION
## Summary

Follow-up to the code review on #2. Two issues fixed:

1. **`convex/ai.js` `generatePlan` — server-side auth**: replaced `const userId = authUserId || args.userId` with a strict `if (!authUserId) throw` + mismatch guard. `args.userId` is still accepted for backwards compat with the onboarding flow, but only when it matches the authed id — never as a fallback. Previously, an unauthenticated caller could pass any victim's user id and the action would still run `onboarding.getByUserId` and `fetchContextForPlanning` with that id before hitting the (now hardened) `savePlan` auth check. `convex/_generated/ai/guidelines.md` says: "NEVER accept a `userId` or any user identifier as a function argument for authorization purposes."

2. **`.filter()` in Convex queries → compound indexes**: `convex/plans.js` `getSharedWeekActivities` and `convex/reflections.js` `getActivitiesForWeekInternal` were scanning `by_plan` / `by_user` and then `.filter()`-ing on `weekNumber` / `number`, which the guidelines explicitly prohibit ("Do NOT use `filter` in queries. Instead, define an index in the schema and use `withIndex` instead."). Added three compound indexes and switched both queries to `withIndex`:
   - `weeks.by_plan_number` → `[planId, number]`
   - `activities.by_plan_week` → `[planId, weekNumber]`
   - `activities.by_user_week` → `[userId, weekNumber]`

Targets `claude/review-pending-features-PEDxn` so it stacks on top of #2.

## Test plan

- [ ] `npx convex dev` starts cleanly (schema validates, new indexes build)
- [ ] Onboarding flow: signup → onboarding → plan generation still works (`generatePlan({ userId: viewer._id })` from `src/app/onboarding/[step]/page.js`)
- [ ] `/plan` regenerate modal still works (`generatePlan({ regenerate: true })` from `src/components/plan/RegeneratePlanModal.js`)
- [ ] Shared plan week view loads activities for a shared plan (`getSharedWeekActivities`)
- [ ] Weekly AI summary still pulls per-week activities (`getActivitiesForWeekInternal`)
- [ ] Unauthenticated direct call to `api.ai.generatePlan({ userId: <any>, regenerate: true })` now throws "Not authenticated" before any downstream reads

🤖 Generated with [Claude Code](https://claude.ai/code)