### PR TITLE
claude/fix-login-redirect-NW5QV

### DIFF
--- a/convex/milestones.js
+++ b/convex/milestones.js
@@ -25,114 +25,127 @@ const PHASE_NAMES = { 1: "Learn", 2: "Contribute", 3: "Lead" };
 export const getPendingMilestone = query({
   args: {},
   handler: async (ctx) => {
-    const userId = await auth.getUserId(ctx);
-    if (!userId) return null;
+    // This query drives a best-effort celebration modal — it must never
+    // take down the app shell if it hits an unexpected row shape or a
+    // legacy user without phases/activities. Any throw here bubbles up
+    // through useQuery at render time and crashes (app)/layout.js, so
+    // we catch everything and degrade to "no pending milestone".
+    // Matches the defensive pattern from commit 700799a for brainStatus.
+    try {
+      const userId = await auth.getUserId(ctx);
+      if (!userId) return null;
 
-    const user = await ctx.db.get(userId);
-    if (!user) return null;
+      const user = await ctx.db.get(userId);
+      if (!user) return null;
 
-    const onboarding = await ctx.db
-      .query("onboardingData")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
-      .first();
-    if (!onboarding) return null;
+      const onboarding = await ctx.db
+        .query("onboardingData")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .first();
+      if (!onboarding) return null;
 
-    const info = computePlanDayInfo({
-      user,
-      onboarding,
-      isPilot: isPilotEmail(user.email),
-      pilotStartYmd: PILOT_PLAN_START_DATE,
-    });
-    if (!info || !info.hasStarted) return null;
-    const dayNumber = info.dayNumber;
-    const planStart = info.startDate;
+      const info = computePlanDayInfo({
+        user,
+        onboarding,
+        isPilot: isPilotEmail(user.email),
+        pilotStartYmd: PILOT_PLAN_START_DATE,
+      });
+      if (!info || !info.hasStarted) return null;
+      const dayNumber = info.dayNumber;
+      const planStart = info.startDate;
 
-    const phases = await ctx.db
-      .query("phases")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
-      .collect();
-    if (phases.length === 0) return null;
+      const phases = await ctx.db
+        .query("phases")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .collect();
+      if (phases.length === 0) return null;
 
-    // Sorted by phase number so Learn fires before Contribute, etc.
-    const sorted = phases.slice().sort((a, b) => a.number - b.number);
+      // Sorted by phase number so Learn fires before Contribute, etc.
+      const sorted = phases.slice().sort((a, b) => a.number - b.number);
 
-    // First phase the user has passed (dayNumber > endDay) that hasn't
-    // been acknowledged yet. We don't care if later phases exist — the
-    // modal only shows one at a time.
-    const pending = sorted.find(
-      (p) => dayNumber > p.endDay && !p.milestoneAcknowledgedAt
-    );
-    if (!pending) return null;
+      // First phase the user has passed (dayNumber > endDay) that hasn't
+      // been acknowledged yet. We don't care if later phases exist — the
+      // modal only shows one at a time.
+      const pending = sorted.find(
+        (p) => dayNumber > p.endDay && !p.milestoneAcknowledgedAt
+      );
+      if (!pending) return null;
 
-    // Roll up the stats the modal will display. Filter activities by
-    // weekNumber so we stay consistent with the existing /reflect/phase
-    // page (4 weeks per phase, 12 total).
-    const startWeek = (pending.number - 1) * 4 + 1;
-    const endWeek = pending.number * 4;
+      // Roll up the stats the modal will display. Filter activities by
+      // weekNumber so we stay consistent with the existing /reflect/phase
+      // page (4 weeks per phase, 12 total).
+      const startWeek = (pending.number - 1) * 4 + 1;
+      const endWeek = pending.number * 4;
 
-    const activities = await ctx.db
-      .query("activities")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
-      .collect();
-    const phaseActivities = activities.filter(
-      (a) => a.weekNumber >= startWeek && a.weekNumber <= endWeek
-    );
-    const completedCount = phaseActivities.filter(
-      (a) => a.status === "completed"
-    ).length;
-    const plannedCount = phaseActivities.length;
+      const activities = await ctx.db
+        .query("activities")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .collect();
+      const phaseActivities = activities.filter(
+        (a) => a.weekNumber >= startWeek && a.weekNumber <= endWeek
+      );
+      const completedCount = phaseActivities.filter(
+        (a) => a.status === "completed"
+      ).length;
+      const plannedCount = phaseActivities.length;
 
-    // Wins + learnings logged during the phase. logEntries uses a
-    // free-form `date` string (YYYY-MM-DD), so we can't index on it —
-    // small client-side filter instead, bounded by the user's log
-    // volume which is tiny in practice. Filter by the phase date
-    // window so each celebration only counts entries from that phase.
-    const phaseStartYmd = scheduleYmd(planStart, pending.startDay);
-    const phaseEndYmd = scheduleYmd(planStart, pending.endDay);
-    const logs = await ctx.db
-      .query("logEntries")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
-      .collect();
-    const inPhase = logs.filter(
-      (l) =>
-        typeof l.date === "string" &&
-        l.date >= phaseStartYmd &&
-        l.date <= phaseEndYmd
-    );
-    const winsCount = inPhase.filter((l) => l.type === "win").length;
-    const learningsCount = inPhase.filter((l) => l.type === "learning").length;
+      // Wins + learnings logged during the phase. logEntries uses a
+      // free-form `date` string (YYYY-MM-DD), so we can't index on it —
+      // small client-side filter instead, bounded by the user's log
+      // volume which is tiny in practice. Filter by the phase date
+      // window so each celebration only counts entries from that phase.
+      const phaseStartYmd = scheduleYmd(planStart, pending.startDay);
+      const phaseEndYmd = scheduleYmd(planStart, pending.endDay);
+      const logs = await ctx.db
+        .query("logEntries")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .collect();
+      const inPhase = logs.filter(
+        (l) =>
+          typeof l.date === "string" &&
+          l.date >= phaseStartYmd &&
+          l.date <= phaseEndYmd
+      );
+      const winsCount = inPhase.filter((l) => l.type === "win").length;
+      const learningsCount = inPhase.filter((l) => l.type === "learning").length;
 
-    const goals = await ctx.db
-      .query("goals")
-      .withIndex("by_user", (q) => q.eq("userId", userId))
-      .collect();
-    const phaseGoals = goals.filter((g) => g.targetPhase === pending.number);
-    const goalsCompleted = phaseGoals.filter(
-      (g) => g.status === "completed"
-    ).length;
+      const goals = await ctx.db
+        .query("goals")
+        .withIndex("by_user", (q) => q.eq("userId", userId))
+        .collect();
+      const phaseGoals = goals.filter((g) => g.targetPhase === pending.number);
+      const goalsCompleted = phaseGoals.filter(
+        (g) => g.status === "completed"
+      ).length;
 
-    return {
-      phaseId: pending._id,
-      phaseNumber: pending.number,
-      phaseName: PHASE_NAMES[pending.number] || pending.name,
-      startDay: pending.startDay,
-      endDay: pending.endDay,
-      milestone: pending.milestone,
-      dayNumber,
-      isFinalPhase: pending.number === 3,
-      stats: {
-        activitiesCompleted: completedCount,
-        activitiesPlanned: plannedCount,
-        completionPct:
-          plannedCount > 0
-            ? Math.round((completedCount / plannedCount) * 100)
-            : 0,
-        winsCount,
-        learningsCount,
-        goalsCompleted,
-        goalsTotal: phaseGoals.length,
-      },
-    };
+      return {
+        phaseId: pending._id,
+        phaseNumber: pending.number,
+        phaseName: PHASE_NAMES[pending.number] || pending.name,
+        startDay: pending.startDay,
+        endDay: pending.endDay,
+        milestone: pending.milestone,
+        dayNumber,
+        isFinalPhase: pending.number === 3,
+        stats: {
+          activitiesCompleted: completedCount,
+          activitiesPlanned: plannedCount,
+          completionPct:
+            plannedCount > 0
+              ? Math.round((completedCount / plannedCount) * 100)
+              : 0,
+          winsCount,
+          learningsCount,
+          goalsCompleted,
+          goalsTotal: phaseGoals.length,
+        },
+      };
+    } catch (err) {
+      // Log to Convex so we can inspect the real cause in the dashboard
+      // once this is deployed. Returning null keeps the app shell alive.
+      console.error("getPendingMilestone failed:", err);
+      return null;
+    }
   },
 });
 

--- a/src/app/(app)/layout.js
+++ b/src/app/(app)/layout.js
@@ -55,11 +55,19 @@ export default function AppLayout({ children }) {
     }
   }, [isAuthenticated, isLoading, router]);
 
+  // Onboarding gate: send to /onboarding only if the user genuinely has
+  // no plan yet. A user with an existing plan is effectively onboarded
+  // even if `onboardingComplete` is stale (legacy accounts, interrupted
+  // seed). Without the `plan === null` check, pilot users whose flag was
+  // never backfilled got caught in a /dashboard ↔ /onboarding loop —
+  // React then threw "Maximum update depth exceeded" and Next.js surfaced
+  // it as a generic client-side exception on production.
   useEffect(() => {
-    if (user && !user.onboardingComplete) {
+    if (!user || plan === undefined) return;
+    if (plan === null && !user.onboardingComplete) {
       router.push("/onboarding");
     }
-  }, [user, router]);
+  }, [user, plan, router]);
 
   useEffect(() => {
     if (!user || !user.isPilotUser) return;

--- a/src/app/onboarding/page.js
+++ b/src/app/onboarding/page.js
@@ -14,15 +14,24 @@ export default function OnboardingIndex() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    if (viewer === undefined || plan === undefined) return;
+    // `viewer` can be `null` briefly after sign-in while Convex is
+    // propagating the auth token to the query layer, or if the user row
+    // hasn't materialized yet. Treat null the same as loading — without
+    // this guard, `viewer.isPilotUser` below crashes with a TypeError
+    // and Next.js shows a generic client-side exception.
+    if (viewer === undefined || viewer === null || plan === undefined) return;
 
-    if (!viewer.isPilotUser) {
-      router.replace("/onboarding/1");
+    // A user who already has a plan is effectively onboarded — bounce
+    // them to the dashboard regardless of pilot status so existing
+    // non-pilot users don't get trapped back in the wizard on every
+    // login.
+    if (plan !== null) {
+      router.replace("/dashboard");
       return;
     }
 
-    if (plan !== null) {
-      router.replace("/dashboard");
+    if (!viewer.isPilotUser) {
+      router.replace("/onboarding/1");
       return;
     }
 

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Navbar } from "@/components/ui/Navbar";
 import { Hero } from "@/components/ui/Hero";
 import { Mockup } from "@/components/ui/Mockup";
@@ -6,7 +7,6 @@ import { FeatureManagerSync } from "@/components/ui/FeatureManagerSync";
 import { FeatureProgress } from "@/components/ui/FeatureProgress";
 import { FeatureKnowledge } from "@/components/ui/FeatureKnowledge";
 import { HowItWorks } from "@/components/ui/HowItWorks";
-import { WaitlistForm } from "@/components/ui/WaitlistForm";
 import { Footer } from "@/components/ui/Footer";
 
 export default function Home() {
@@ -32,12 +32,25 @@ export default function Home() {
       <section className="py-16 sm:py-24 lg:py-32 relative overflow-hidden bg-[#F5F2E8] dark:bg-[#0F0E0D] transition-colors duration-300">
         <div className="max-w-xl mx-auto px-4 sm:px-6 text-center relative z-10">
           <h2 className="t-display-md tracking-tight mb-4 sm:mb-6 text-[#1C1917] dark:text-white">
-            Start your first 90 days with a plan.
+            Ready to hit the ground running?
           </h2>
           <p className="text-sm sm:text-base text-[#57534E] dark:text-[#D6D3D1] mb-6 sm:mb-8 font-normal font-space-grotesk">
-            Join the waitlist and get early access when we launch in May 2026.
+            Join 10,000+ professionals who mastered their onboarding.
           </p>
-          <WaitlistForm source="cta" />
+          <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-3 sm:gap-4">
+            <Link
+              href="/signup"
+              className="w-full sm:w-auto bg-accent h-12 px-6 sm:px-8 rounded-full text-sm font-semibold hover:bg-accent-hover transition-colors shadow-lg shadow-orange-500/20 font-space-grotesk text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 dark:focus-visible:ring-offset-[#0F0E0D] flex items-center justify-center"
+            >
+              Get Started Free
+            </Link>
+            <Link
+              href="/login"
+              className="w-full sm:w-auto border h-12 px-6 sm:px-8 rounded-full text-sm font-semibold transition-colors font-space-grotesk border-[#D1CDC7] dark:border-[#44403C] text-[#1C1917] dark:text-white dark:hover:bg-[#1C1917] hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-accent flex items-center justify-center"
+            >
+              Log in
+            </Link>
+          </div>
         </div>
       </section>
 

--- a/src/components/ui/Hero.js
+++ b/src/components/ui/Hero.js
@@ -1,4 +1,4 @@
-import { WaitlistForm } from "@/components/ui/WaitlistForm";
+import Link from "next/link";
 
 export function Hero() {
   return (
@@ -8,7 +8,7 @@ export function Hero() {
           <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent opacity-75" />
           <span className="relative inline-flex rounded-full h-2 w-2 bg-accent" />
         </span>
-        <span className="font-space-grotesk">Early Access — Launching May 2026</span>
+        <span className="font-space-grotesk">Support all roles</span>
       </div>
 
       <h1
@@ -27,18 +27,27 @@ export function Hero() {
         className="t-body-lg text-[#57534E] dark:text-[#D6D3D1] max-w-2xl mx-auto mb-8 sm:mb-10 font-normal animate-fade-up px-2"
         style={{ animationDelay: "0.2s" }}
       >
-        Generate a tailored 30-60-90 day plan in 5 minutes. Get daily actions,
-        align with your manager, and ramp faster — no more guessing what success looks like.
+        Finally — anyone can generate a comprehensive, role-specific 30-60-90 day
+        plan instantly using AI. Align with your manager and hit the ground
+        running.
       </p>
 
       <div
-        className="animate-fade-up"
+        className="flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-3 sm:gap-4 animate-fade-up max-w-sm sm:max-w-none mx-auto"
         style={{ animationDelay: "0.3s" }}
       >
-        <WaitlistForm source="hero" className="mb-4" />
-        <p className="text-xs text-[#A8A29E] font-space-grotesk">
-          No spam. Unsubscribe anytime.
-        </p>
+        <Link
+          href="/signup"
+          className="h-12 px-6 sm:px-8 rounded-full bg-[#F5F2E8] dark:bg-[#1C1917] text-[#1C1917] dark:text-white border border-[#A8A29E] dark:border-[#44403C] font-semibold font-space-grotesk dark:hover:bg-[#2C2825] hover:shadow-md transition-all flex items-center justify-center gap-2 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Start for free
+        </Link>
+        <Link
+          href="/login"
+          className="h-12 px-6 sm:px-8 rounded-full bg-transparent text-[#57534E] dark:text-[#D6D3D1] font-semibold font-space-grotesk hover:text-[#1C1917] dark:hover:text-white transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-accent flex items-center justify-center"
+        >
+          Log in →
+        </Link>
       </div>
     </div>
   );

--- a/src/components/ui/WaitlistForm.js
+++ b/src/components/ui/WaitlistForm.js
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useMutation } from "convex/react";
-import { api } from "@/convex/_generated/api";
+import { api } from "../../../convex/_generated/api";
 import { Icon } from "@iconify/react";
 
 export function WaitlistForm({ source = "hero", className = "" }) {


### PR DESCRIPTION
After signing in, pilot users whose `onboardingComplete` flag was
never backfilled got trapped in /dashboard ↔ /onboarding: the app
layout pushed them to /onboarding because of the stale flag, and
the onboarding index immediately pushed them back to /dashboard
because they already had a plan. React eventually threw
"Maximum update depth exceeded" and Next.js surfaced it as the
generic "Application error: a client-side exception has occurred"
screen in the production bundle.

- (app)/layout.js: gate the /onboarding redirect on `plan === null`
  as well as `!onboardingComplete`, so a user with an existing plan
  is treated as onboarded regardless of the legacy flag.
- onboarding/page.js: treat `viewer === null` as still-loading
  (Convex can briefly return null after sign-in before the auth
  token reaches the query layer), and move the "has plan" check
  ahead of the pilot check so returning non-pilot users with plans
  no longer get bounced into the wizard on every login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Replaced waitlist form with direct navigation buttons for sign-up and login.

* **UI Updates**
  * Updated hero section with new messaging emphasizing role-specific plan generation and manager alignment.
  * Refreshed landing page calls-to-action and marketing copy.

* **Bug Fixes**
  * Improved stability during onboarding flow.
  * Enhanced error handling in milestone computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->