### PR TITLE
fix(icons): install offline Solar+RI bundles — fix missing icons in prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@convex-dev/auth": "^0.0.91",
         "@convex-dev/rag": "^0.7.2",
         "@convex-dev/workpool": "^0.3.2",
+        "@iconify-json/ri": "^1.2.10",
+        "@iconify-json/solar": "^1.2.5",
         "@iconify/react": "^6.0.2",
         "chart.js": "^4.5.1",
         "clsx": "^2.1.1",
@@ -1130,6 +1132,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@iconify-json/ri": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@iconify-json/ri/-/ri-1.2.10.tgz",
+      "integrity": "sha512-WWMhoncVVM+Xmu9T5fgu2lhYRrKTEWhKk3Com0KiM111EeEsRLiASjpsFKnC/SrB6covhUp95r2mH8tGxhgd5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify-json/solar": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@iconify-json/solar/-/solar-1.2.5.tgz",
+      "integrity": "sha512-WMAiNwchU8zhfrySww6KQBRIBbsQ6SvgIu2yA+CHGyMima/0KQwT5MXogrZPJGoQF+1Ye3Qj6K+1CiyNn3YkoA==",
+      "license": "CC-BY-4.0",
+      "dependencies": {
+        "@iconify/types": "*"
       }
     },
     "node_modules/@iconify/react": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@convex-dev/auth": "^0.0.91",
     "@convex-dev/rag": "^0.7.2",
     "@convex-dev/workpool": "^0.3.2",
+    "@iconify-json/ri": "^1.2.10",
+    "@iconify-json/solar": "^1.2.5",
     "@iconify/react": "^6.0.2",
     "chart.js": "^4.5.1",
     "clsx": "^2.1.1",

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,6 +1,7 @@
 import Script from "next/script";
 import { Inter, Instrument_Serif, Space_Grotesk } from "next/font/google";
 import ConvexClientProvider from "@/components/providers/ConvexClientProvider";
+import IconifyProvider from "@/components/providers/IconifyProvider";
 import "./globals.css";
 
 const inter = Inter({
@@ -57,9 +58,11 @@ export default function RootLayout({ children }) {
         <Script id="theme-init" strategy="beforeInteractive">
           {themeInit}
         </Script>
-        <ConvexClientProvider>
-          {children}
-        </ConvexClientProvider>
+        <IconifyProvider>
+          <ConvexClientProvider>
+            {children}
+          </ConvexClientProvider>
+        </IconifyProvider>
       </body>
     </html>
   );

--- a/src/components/providers/IconifyProvider.js
+++ b/src/components/providers/IconifyProvider.js
@@ -1,0 +1,14 @@
+"use client";
+
+import { addCollection } from "@iconify/react";
+import solarIcons from "@iconify-json/solar/icons.json";
+import riIcons from "@iconify-json/ri/icons.json";
+
+// Pre-register both icon sets so @iconify/react finds them locally
+// without making any CDN requests. This keeps the strict connect-src CSP intact.
+addCollection(solarIcons);
+addCollection(riIcons);
+
+export default function IconifyProvider({ children }) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `@iconify/react` fetches icon SVGs from `api.iconify.design` at runtime. The strict `connect-src` CSP introduced in `f10f8b9` blocks all Iconify CDN domains — icons render as empty boxes across every UI surface.
- **FIR-42 status**: Previously marked done with commit `b7bcec9`, but that commit was never pushed to the remote. This PR is the actual fix.
- **Branch `claude/analyze-knowledgebase-features-O397V`** referenced in FIR-51 does not exist on the remote; `claude/review-knowledgebase-architecture-EYamu` is the closest branch and it has the same missing fix (no offline bundles, no IconifyProvider).

## Changes

- `package.json` / `package-lock.json`: add `@iconify-json/solar` and `@iconify-json/ri` offline icon bundles
- `src/components/providers/IconifyProvider.js`: new client component that calls `addCollection()` for both sets at module load time — Iconify resolves icons locally before attempting any CDN fetch
- `src/app/layout.js`: wrap app tree in `<IconifyProvider>`

## Why offline over CSP relaxation

Offline bundles mean zero runtime CDN dependency and no changes needed to the strict `connect-src`. All icon data ships with the JS bundle.

## Test plan

- [ ] `npm run build` passes
- [ ] All Solar icons render correctly in KB, onboarding, nav, and activity surfaces
- [ ] No `api.iconify.design` requests appear in the network tab

🤖 Generated with [Claude Code](https://claude.ai/claude-code)