### PR TITLE
fix(onboarding): call completeOnboarding before navigating away on skip

### DIFF
--- a/src/app/onboarding/layout.js
+++ b/src/app/onboarding/layout.js
@@ -1,6 +1,7 @@
 "use client";
 
-import { useConvexAuth } from "convex/react";
+import { useConvexAuth, useMutation } from "convex/react";
+import { api } from "../../../convex/_generated/api";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Link from "next/link";
@@ -11,6 +12,7 @@ export default function OnboardingLayout({ children }) {
   const router = useRouter();
   const [saveVisible, setSaveVisible] = useState(false);
   const [showSkipConfirm, setShowSkipConfirm] = useState(false);
+  const completeOnboarding = useMutation(api.users.completeOnboarding);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -89,7 +91,10 @@ export default function OnboardingLayout({ children }) {
               </button>
               <button
                 type="button"
-                onClick={() => router.push("/dashboard")}
+                onClick={async () => {
+                  await completeOnboarding();
+                  router.push("/dashboard");
+                }}
                 className="flex-1 px-4 py-2.5 rounded-lg font-space-grotesk text-sm font-medium text-white bg-accent hover:bg-accent-hover transition-colors"
               >
                 Skip anyway


### PR DESCRIPTION
## Summary

Fixes FIR-52 — infinite redirect loop when users click "Skip for now" in onboarding.

**Root cause:** The skip button in `src/app/onboarding/layout.js` called `router.push("/dashboard")` without setting `onboardingComplete=true`. The `(app)/layout.js` redirect guard checked `!user.onboardingComplete` and immediately bounced the user back to `/onboarding`, creating an infinite loop.

**Fix:**
- Added `useMutation(api.users.completeOnboarding)` to the onboarding layout
- Skip handler now awaits `completeOnboarding()` before navigating to `/dashboard`
- The app layout guard is satisfied on arrival — no redirect loop

## Test plan
- [ ] Create a new account and enter the onboarding flow
- [ ] Click "Skip for now" — should land on `/dashboard` and stay there
- [ ] Confirm no redirect back to `/onboarding`
- [ ] Verify completing onboarding normally still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)