### PR TITLE
fix(onboarding): call completeOnboarding mutation when user clicks skip

### DIFF
--- a/src/app/onboarding/layout.js
+++ b/src/app/onboarding/layout.js
@@ -1,6 +1,7 @@
 "use client";
 
-import { useConvexAuth } from "convex/react";
+import { useConvexAuth, useMutation } from "convex/react";
+import { api } from "../../../convex/_generated/api";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Link from "next/link";
@@ -11,6 +12,7 @@ export default function OnboardingLayout({ children }) {
   const router = useRouter();
   const [saveVisible, setSaveVisible] = useState(false);
   const [showSkipConfirm, setShowSkipConfirm] = useState(false);
+  const completeOnboarding = useMutation(api.users.completeOnboarding);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -89,7 +91,10 @@ export default function OnboardingLayout({ children }) {
               </button>
               <button
                 type="button"
-                onClick={() => router.push("/dashboard")}
+                onClick={async () => {
+                  await completeOnboarding();
+                  router.push("/dashboard");
+                }}
                 className="flex-1 px-4 py-2.5 rounded-lg font-space-grotesk text-sm font-medium text-white bg-accent hover:bg-accent-hover transition-colors"
               >
                 Skip anyway


### PR DESCRIPTION
The "Skip anyway" button only did a client-side redirect to /dashboard
without setting onboardingComplete in the database. The app layout guard
then redirected back to /onboarding because the flag was still false,
creating an infinite loop. Now we await the existing completeOnboarding
mutation before navigating.

https://claude.ai/code/session_01E3PBQ6URE74Z8hhV8ZejfR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Skip anyway" button in onboarding to properly record completion before navigating to the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->