### PR TITLE
fix(ux): add empty states for all pages when user skips onboarding

### DIFF
--- a/src/app/(app)/dashboard/page.js
+++ b/src/app/(app)/dashboard/page.js
@@ -86,7 +86,7 @@ export default function DashboardPage() {
             ? `your journey begins on ${formatStartDate(dayInfo.startDate)}`
             : dayInfo && dayInfo.hasStarted
               ? `you're on Day ${dayInfo.dayNumber} — ${dayInfo.phaseName} phase`
-              : "let's get started"}
+              : "complete onboarding to generate your personalised plan"}
         </p>
       </div>
 

--- a/src/app/(app)/plan/page.js
+++ b/src/app/(app)/plan/page.js
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import SharePlanModal from "@/components/plan/SharePlanModal";
 import RegeneratePlanModal from "@/components/plan/RegeneratePlanModal";
+import NoPlanEmptyState from "@/components/app/NoPlanEmptyState";
 import {
   buildPlanMarkdown,
   buildPlanJson,
@@ -87,13 +88,32 @@ export default function PlanPage() {
     setExportOpen(false);
   }
 
-  if (!fullPlan) {
+  if (fullPlan === undefined) {
     return (
       <div className="space-y-4">
         <div className="h-10 bg-[#1C1917] rounded-lg animate-pulse w-2/3" />
         {[1, 2, 3, 4].map((i) => (
           <div key={i} className="h-24 bg-[#1C1917] border border-[#2C2825] rounded-xl animate-pulse" />
         ))}
+      </div>
+    );
+  }
+
+  if (fullPlan === null) {
+    return (
+      <div className="space-y-6 sm:space-y-8">
+        <div>
+          <h1 className="font-instrument-serif tracking-[-0.5px] sm:tracking-[-0.9px] text-2xl sm:text-3xl md:text-4xl leading-tight">
+            Your 90-Day Trajectory
+          </h1>
+          <p className="mt-2 font-space-grotesk text-sm sm:text-base text-[#A8A29E]">
+            Your strategic plan
+          </p>
+        </div>
+        <NoPlanEmptyState
+          heading="Your plan starts here"
+          description="This is where your strategic plan lives — 12 weeks of activities across three phases (Learn, Contribute, Lead). Complete onboarding to generate a plan tailored to your role and company."
+        />
       </div>
     );
   }

--- a/src/app/(app)/progress/page.js
+++ b/src/app/(app)/progress/page.js
@@ -2,7 +2,7 @@
 
 import { useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
-import Link from "next/link";
+import NoPlanEmptyState from "@/components/app/NoPlanEmptyState";
 
 const categoryLabels = {
   learning: "Learning",
@@ -100,25 +100,19 @@ export default function ProgressPage() {
 
   if (v === null) {
     return (
-      <div className="space-y-6">
-        <h1 className="font-instrument-serif text-4xl tracking-[-0.9px] leading-[40px]">
-          Progress
-        </h1>
-        <div className="bg-[#1C1917] border border-[#2C2825] rounded-xl p-8 text-center">
-          <p className="font-instrument-serif text-2xl text-[#E7E5E4]">
-            No plan yet
+      <div className="space-y-6 sm:space-y-8">
+        <div>
+          <h1 className="font-instrument-serif text-4xl tracking-[-0.9px] leading-[40px]">
+            Progress & Velocity
+          </h1>
+          <p className="mt-2 font-space-grotesk text-sm sm:text-base text-[#A8A29E]">
+            Your performance tracker
           </p>
-          <p className="mt-2 font-space-grotesk text-sm text-[#A8A29E]">
-            Finish onboarding to generate a plan — velocity tracking starts the
-            moment you have activities scheduled.
-          </p>
-          <Link
-            href="/onboarding/1"
-            className="inline-block mt-4 bg-[#D97757] hover:bg-[#C26242] text-white rounded-lg px-4 py-2 font-space-grotesk text-sm font-medium transition"
-          >
-            Continue setup →
-          </Link>
         </div>
+        <NoPlanEmptyState
+          heading="See how you're tracking"
+          description="Track how you're performing against your 90-day plan — pace ratio, weekly burn-up, and category balance. Complete onboarding to start tracking."
+        />
       </div>
     );
   }

--- a/src/app/(app)/stakeholders/page.js
+++ b/src/app/(app)/stakeholders/page.js
@@ -5,6 +5,7 @@ import { api } from "../../../../convex/_generated/api";
 import Link from "next/link";
 import { useState } from "react";
 import { ResponsiveModal, ScrollableTabs } from "@/components/primitives";
+import NoPlanEmptyState from "@/components/app/NoPlanEmptyState";
 
 const SORT_TABS = [
   { key: "priority", label: "Priority" },
@@ -87,6 +88,13 @@ export default function StakeholdersPage() {
         </button>
       </div>
 
+      {stakeholders.length === 0 ? (
+        <NoPlanEmptyState
+          heading="Build your network"
+          description="Map out the key people you need to build relationships with. You can add stakeholders now, or complete onboarding to get AI-suggested contacts based on your role."
+        />
+      ) : (
+      <>
       {/* Sort */}
       <ScrollableTabs
         items={SORT_TABS}
@@ -150,6 +158,8 @@ export default function StakeholdersPage() {
           </Link>
         ))}
       </div>
+      </>
+      )}
 
       <ResponsiveModal
         open={showForm}

--- a/src/app/(app)/tasks/page.js
+++ b/src/app/(app)/tasks/page.js
@@ -4,6 +4,8 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { useState } from "react";
 import { ScrollableTabs } from "@/components/primitives";
+import NoPlanEmptyState from "@/components/app/NoPlanEmptyState";
+import { useHasPlan } from "@/hooks/useHasPlan";
 
 const STATUS_TABS = [
   { key: "all", label: "All" },
@@ -31,6 +33,7 @@ export default function TasksPage() {
   const allActivities = useQuery(api.activities.getAll);
   const goals = useQuery(api.goals.list);
   const dayInfo = useQuery(api.users.getDayNumber);
+  const { hasPlan } = useHasPlan();
   const completeActivity = useMutation(api.activities.complete);
   const [filter, setFilter] = useState("all");
   const [categoryFilter, setCategoryFilter] = useState("all");
@@ -42,6 +45,25 @@ export default function TasksPage() {
         {[1, 2, 3, 4, 5].map((i) => (
           <div key={i} className="h-16 bg-[#1C1917] border border-[#2C2825] rounded-xl animate-pulse" />
         ))}
+      </div>
+    );
+  }
+
+  if (allActivities.length === 0 && !hasPlan) {
+    return (
+      <div className="space-y-6 sm:space-y-8">
+        <div>
+          <h1 className="font-instrument-serif tracking-[-0.5px] sm:tracking-[-0.9px] text-2xl sm:text-3xl md:text-4xl leading-tight">
+            Tasks & Milestones
+          </h1>
+          <p className="mt-2 font-space-grotesk text-sm sm:text-base text-[#A8A29E]">
+            Your activity tracker
+          </p>
+        </div>
+        <NoPlanEmptyState
+          heading="Track your progress"
+          description="Track and manage every activity in your 90-day plan. Complete onboarding to generate your tasks, grouped by week and category."
+        />
       </div>
     );
   }

--- a/src/app/(app)/today/page.js
+++ b/src/app/(app)/today/page.js
@@ -5,6 +5,7 @@ import { api } from "../../../../convex/_generated/api";
 import { useState } from "react";
 import Link from "next/link";
 import StakeholderNudges from "@/components/stakeholders/StakeholderNudges";
+import NoPlanEmptyState from "@/components/app/NoPlanEmptyState";
 import { useToast } from "@/components/primitives/Toaster";
 
 const categoryColors = {
@@ -38,10 +39,29 @@ export default function TodayPage() {
   const [reschedulingId, setReschedulingId] = useState(null);
   const [rescheduleDate, setRescheduleDate] = useState("");
 
-  if (!dayInfo) {
+  if (dayInfo === undefined) {
     return (
       <div className="flex items-center justify-center py-20">
         <div className="w-8 h-8 border-2 border-[#D97757] border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (dayInfo === null) {
+    return (
+      <div className="space-y-6 sm:space-y-8">
+        <div>
+          <h1 className="font-instrument-serif tracking-[-0.5px] sm:tracking-[-0.9px] text-2xl sm:text-3xl md:text-4xl leading-tight">
+            Today
+          </h1>
+          <p className="mt-2 font-space-grotesk text-sm sm:text-base text-[#A8A29E]">
+            Your daily view
+          </p>
+        </div>
+        <NoPlanEmptyState
+          heading="Your day starts with a plan"
+          description="The Today view shows your daily activities, progress, and streak. Complete onboarding to generate your personalised 90-day plan."
+        />
       </div>
     );
   }

--- a/src/components/app/NoPlanEmptyState.js
+++ b/src/components/app/NoPlanEmptyState.js
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+
+export default function NoPlanEmptyState({
+  heading,
+  description,
+  ctaLabel = "Complete setup",
+  ctaHref = "/onboarding/1",
+}) {
+  return (
+    <div className="bg-[#1C1917] border border-[#2C2825] rounded-xl p-6 sm:p-8 text-center space-y-4">
+      <h2 className="font-instrument-serif text-2xl text-[#E7E5E4]">
+        {heading}
+      </h2>
+      <p className="font-space-grotesk text-sm text-[#A8A29E] max-w-md mx-auto">
+        {description}
+      </p>
+      <div>
+        <Link
+          href={ctaHref}
+          className="inline-flex bg-[#D97757] hover:bg-[#C26242] text-white rounded-lg px-6 py-2.5 font-space-grotesk text-sm font-medium transition shadow-sm"
+        >
+          {ctaLabel}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/app/QuickAddFAB.js
+++ b/src/components/app/QuickAddFAB.js
@@ -4,11 +4,13 @@ import { useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { ResponsiveModal } from "@/components/primitives";
+import { useHasPlan } from "@/hooks/useHasPlan";
 
 export default function QuickAddFAB() {
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState(null); // 'activity' | 'win' | 'learning'
   const dayInfo = useQuery(api.users.getDayNumber);
+  const { hasPlan, isLoading: planLoading } = useHasPlan();
   const createActivity = useMutation(api.activities.create);
   const createLogEntry = useMutation(api.logEntries.create);
 
@@ -98,20 +100,33 @@ export default function QuickAddFAB() {
       {open && !mode && (
         <div className="fixed right-[max(1.25rem,env(safe-area-inset-right))] z-[55] bg-warm-cardDark border border-warm-borderDark rounded-xl shadow-xl w-56 overflow-hidden bottom-[calc(var(--bottom-nav-h)+5rem)] lg:bottom-[calc(2rem+4.5rem)]">
           {[
-            { key: "activity", label: "Add Activity", icon: "📋" },
+            { key: "activity", label: "Add Activity", icon: "📋", requiresPlan: true },
             { key: "win", label: "Log a Win", icon: "🏆" },
             { key: "learning", label: "Log a Learning", icon: "💡" },
-          ].map((item) => (
-            <button
-              key={item.key}
-              type="button"
-              onClick={() => setMode(item.key)}
-              className="w-full flex items-center gap-3 px-4 py-3 font-space-grotesk text-sm text-warm-line hover:bg-warm-surfaceDark transition-colors text-left min-h-11"
-            >
-              <span aria-hidden="true">{item.icon}</span>
-              {item.label}
-            </button>
-          ))}
+          ].map((item) => {
+            const disabled = item.requiresPlan && (!hasPlan || planLoading);
+            return (
+              <button
+                key={item.key}
+                type="button"
+                disabled={disabled}
+                onClick={() => !disabled && setMode(item.key)}
+                className={`w-full flex items-center gap-3 px-4 py-3 font-space-grotesk text-sm text-left min-h-11 ${
+                  disabled
+                    ? "text-warm-500 cursor-not-allowed opacity-50"
+                    : "text-warm-line hover:bg-warm-surfaceDark transition-colors"
+                }`}
+              >
+                <span aria-hidden="true">{item.icon}</span>
+                <span className="flex flex-col">
+                  {item.label}
+                  {disabled && (
+                    <span className="text-[10px] text-warm-500">Requires a plan</span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
         </div>
       )}
 

--- a/src/hooks/useHasPlan.js
+++ b/src/hooks/useHasPlan.js
@@ -1,0 +1,13 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+
+export function useHasPlan() {
+  const plan = useQuery(api.plans.get);
+  return {
+    plan,
+    hasPlan: plan !== undefined && plan !== null,
+    isLoading: plan === undefined,
+  };
+}


### PR DESCRIPTION
When a user clicks "Skip for now" during onboarding, no plan data is
created. Previously this caused infinite loading spinners (Today, Plan),
meaningless zero-stat displays (Tasks), empty lists with no guidance
(Stakeholders), and an unhandled error when using the QuickAdd FAB.

- Add useHasPlan hook for three-state plan detection (loading/no-plan/has-plan)
- Add shared NoPlanEmptyState component with contextual messaging and CTA
- Fix Today page: distinguish loading vs no-data, show setup prompt
- Fix Plan page: distinguish loading vs no-plan, show setup prompt
- Fix Tasks page: show setup prompt instead of misleading zero stats
- Fix Stakeholders page: show guidance when list is empty
- Fix Progress page: consistent empty state design
- Fix Dashboard: clearer subtitle for new users without a plan
- Fix QuickAdd FAB: disable "Add Activity" when no plan exists

https://claude.ai/code/session_01T3CWnLYGBCJFv8phn2aiYe