### PR TITLE
fix(onboarding): audit fixes + post-onboarding plan context editing

### DIFF
--- a/convex/onboarding.js
+++ b/convex/onboarding.js
@@ -98,9 +98,24 @@ export const updateContext = mutation({
       .first();
     if (!existing) throw new Error("No onboarding data found");
 
+    // Server-side length caps. These match the UI constraints but also
+    // protect the prompt-token budget when the Settings page is bypassed.
+    const MAX_LEN = {
+      scope: 500,
+      reportsTo: 200,
+      successDefinition: 2000,
+      existingContext: 4000,
+      challenges: 4000,
+      jobDescription: 12000,
+    };
+
     const patch = {};
     for (const [key, value] of Object.entries(args)) {
-      if (value !== undefined) patch[key] = value;
+      if (value === undefined) continue;
+      if (typeof value === "string" && MAX_LEN[key] && value.length > MAX_LEN[key]) {
+        throw new Error(`${key} exceeds ${MAX_LEN[key]} characters`);
+      }
+      patch[key] = value;
     }
     if (Object.keys(patch).length === 0) return existing._id;
 

--- a/convex/onboarding.js
+++ b/convex/onboarding.js
@@ -69,3 +69,42 @@ export const save = mutation({
     });
   },
 });
+
+/**
+ * Patch a subset of onboarding fields post-onboarding. Used by the
+ * Settings page so users can correct or enrich their plan context
+ * without re-running the whole onboarding flow. Only exposes fields
+ * that are safe to edit mid-plan (we deliberately do NOT let users
+ * change structural fields like starsSituation, companyName, startDate
+ * — those would invalidate the generated plan).
+ */
+export const updateContext = mutation({
+  args: {
+    scope: v.optional(v.string()),
+    reportsTo: v.optional(v.string()),
+    selectedGoals: v.optional(v.array(v.string())),
+    existingContext: v.optional(v.string()),
+    challenges: v.optional(v.string()),
+    successDefinition: v.optional(v.string()),
+    jobDescription: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await auth.getUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const existing = await ctx.db
+      .query("onboardingData")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .first();
+    if (!existing) throw new Error("No onboarding data found");
+
+    const patch = {};
+    for (const [key, value] of Object.entries(args)) {
+      if (value !== undefined) patch[key] = value;
+    }
+    if (Object.keys(patch).length === 0) return existing._id;
+
+    await ctx.db.patch(existing._id, patch);
+    return existing._id;
+  },
+});

--- a/convex/seed.js
+++ b/convex/seed.js
@@ -283,6 +283,11 @@ async function _seedPlanData(ctx, userId) {
         companyStage: "Growth",
         starsSituation: "Turnaround",
         scope: "Leading product design for Agent Studio, defining design direction and interaction patterns for AI agent interfaces",
+        experienceYears: 8,
+        teamSize: 12,
+        isNewTeam: true,
+        workModel: "Hybrid",
+        reportsTo: "Imogen Chen, VP of Product",
       },
     });
     await ctx.scheduler.runAfter(

--- a/src/app/(app)/settings/page.js
+++ b/src/app/(app)/settings/page.js
@@ -909,6 +909,7 @@ function PlanContextSection({
                 type="text"
                 value={contextForm.scope}
                 onChange={bind("scope")}
+                maxLength={500}
                 className={fieldInputClass}
                 placeholder="e.g. Leading product design for the Agent Studio team"
               />

--- a/src/app/(app)/settings/page.js
+++ b/src/app/(app)/settings/page.js
@@ -118,6 +118,7 @@ export default function SettingsPage() {
 
   const updateSettings = useMutation(api.users.updateSettings);
   const updateProfile = useMutation(api.users.updateProfile);
+  const updateOnboardingContext = useMutation(api.onboarding.updateContext);
   const generateAvatarUploadUrl = useMutation(api.users.generateAvatarUploadUrl);
   const setAvatar = useMutation(api.users.setAvatar);
   const removeAvatar = useMutation(api.users.removeAvatar);
@@ -156,6 +157,18 @@ export default function SettingsPage() {
   const [profileSaving, setProfileSaving] = useState(false);
   const [profileSaved, setProfileSaved] = useState(false);
   const [profileError, setProfileError] = useState("");
+
+  const [contextForm, setContextForm] = useState({
+    scope: "",
+    reportsTo: "",
+    successDefinition: "",
+    existingContext: "",
+    challenges: "",
+    jobDescription: "",
+  });
+  const [contextSaving, setContextSaving] = useState(false);
+  const [contextSaved, setContextSaved] = useState(false);
+  const [contextError, setContextError] = useState("");
 
   const [avatarUploading, setAvatarUploading] = useState(false);
   const [avatarError, setAvatarError] = useState("");
@@ -217,6 +230,26 @@ export default function SettingsPage() {
   }, [onboarding?.roleTitle]);
 
   useEffect(() => {
+    if (!onboarding) return;
+    setContextForm({
+      scope: onboarding.scope ?? "",
+      reportsTo: onboarding.reportsTo ?? "",
+      successDefinition: onboarding.successDefinition ?? "",
+      existingContext: onboarding.existingContext ?? "",
+      challenges: onboarding.challenges ?? "",
+      jobDescription: onboarding.jobDescription ?? "",
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    onboarding?.scope,
+    onboarding?.reportsTo,
+    onboarding?.successDefinition,
+    onboarding?.existingContext,
+    onboarding?.challenges,
+    onboarding?.jobDescription,
+  ]);
+
+  useEffect(() => {
     if (!user?.settings) return;
     const s = user.settings;
     setAccountForm((prev) => ({
@@ -262,6 +295,29 @@ export default function SettingsPage() {
       addToast(err?.message ?? "Failed to save profile", "error");
     } finally {
       setProfileSaving(false);
+    }
+  }
+
+  async function handleContextSave() {
+    setContextError("");
+    setContextSaving(true);
+    try {
+      await updateOnboardingContext({
+        scope: contextForm.scope,
+        reportsTo: contextForm.reportsTo,
+        successDefinition: contextForm.successDefinition,
+        existingContext: contextForm.existingContext,
+        challenges: contextForm.challenges,
+        jobDescription: contextForm.jobDescription,
+      });
+      setContextSaved(true);
+      setTimeout(() => setContextSaved(false), 2000);
+      addToast("Plan context saved", "success");
+    } catch (err) {
+      setContextError(err?.message ?? "Failed to save plan context");
+      addToast(err?.message ?? "Failed to save plan context", "error");
+    } finally {
+      setContextSaving(false);
     }
   }
 
@@ -565,6 +621,17 @@ export default function SettingsPage() {
                 onProfileSave={handleProfileSave}
               />
 
+              {onboarding && (
+                <PlanContextSection
+                  contextForm={contextForm}
+                  setContextForm={setContextForm}
+                  saving={contextSaving}
+                  saved={contextSaved}
+                  error={contextError}
+                  onSave={handleContextSave}
+                />
+              )}
+
               <DangerZone
                 confirmDelete={confirmDelete}
                 setConfirmDelete={setConfirmDelete}
@@ -800,6 +867,121 @@ function ProfileSection({
             saved={profileSaved}
             error={profileError}
             onSave={onProfileSave}
+          />
+        </form>
+      </SettingsCard>
+    </section>
+  );
+}
+
+function PlanContextSection({
+  contextForm,
+  setContextForm,
+  saving,
+  saved,
+  error,
+  onSave,
+}) {
+  function bind(key) {
+    return (e) =>
+      setContextForm((s) => ({ ...s, [key]: e.target.value }));
+  }
+  return (
+    <section className="space-y-4">
+      <SectionHeader
+        title="Plan context"
+        description="The intel we use when drafting or regenerating your plan. Update anytime — changes take effect the next time you regenerate."
+      />
+
+      <SettingsCard>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSave();
+          }}
+        >
+          <div className="p-6 space-y-5">
+            <Field
+              label="Role scope"
+              hint="One sentence on what you're actually doing in this role."
+            >
+              <input
+                type="text"
+                value={contextForm.scope}
+                onChange={bind("scope")}
+                className={fieldInputClass}
+                placeholder="e.g. Leading product design for the Agent Studio team"
+              />
+            </Field>
+
+            <Field label="Who do you report to?">
+              <input
+                type="text"
+                value={contextForm.reportsTo}
+                onChange={bind("reportsTo")}
+                className={fieldInputClass}
+                placeholder="e.g. Sarah Jenkins, VP of Product"
+              />
+            </Field>
+
+            <Field
+              label="What does success look like at 90 days?"
+              hint="Your personal definition — not just what the company expects."
+            >
+              <textarea
+                rows={3}
+                value={contextForm.successDefinition}
+                onChange={bind("successDefinition")}
+                className={fieldInputClass}
+                placeholder="e.g. Strong relationships with key stakeholders, a clear understanding of the roadmap, and one shipped improvement."
+              />
+            </Field>
+
+            <Field
+              label="Existing context"
+              hint="Intel from interviews, conversations, or research."
+            >
+              <textarea
+                rows={3}
+                value={contextForm.existingContext}
+                onChange={bind("existingContext")}
+                className={fieldInputClass}
+                placeholder="e.g. The team recently went through a reorg. Engineering is migrating to a new architecture…"
+              />
+            </Field>
+
+            <Field
+              label="Known challenges or risks"
+              hint="Things you want to watch out for or navigate carefully."
+            >
+              <textarea
+                rows={3}
+                value={contextForm.challenges}
+                onChange={bind("challenges")}
+                className={fieldInputClass}
+                placeholder="e.g. My predecessor left on bad terms. The team hasn't had a dedicated PM in 3 months…"
+              />
+            </Field>
+
+            <Field
+              label="Job description"
+              hint="Paste the full JD. We'll use it for grounding research and plan drafts."
+            >
+              <textarea
+                rows={5}
+                value={contextForm.jobDescription}
+                onChange={bind("jobDescription")}
+                className={fieldInputClass}
+                placeholder="Paste the full job description text here…"
+              />
+            </Field>
+          </div>
+
+          <SaveBar
+            saving={saving}
+            saved={saved}
+            error={error}
+            onSave={onSave}
           />
         </form>
       </SettingsCard>


### PR DESCRIPTION
## Summary

End-to-end audit of onboarding data collection → storage → plan/research consumption, plus fixes for the highest-impact gaps found.

### Onboarding audit fixes (commit 1)
- **Pilot seed data corrected** — was "Senior UX Researcher" with invalid `roleType: "Individual Contributor"`; now "Staff Product Designer" (Agent Studio) with `roleType: "Design"`. Added the 6 missing optional fields (`reportsTo`, `selectedGoals`, `successDefinition`, `existingContext`, `challenges`, `jobDescription`) so the pilot experience showcases the product's full personalization.
- **`scope` UI input added** to Step 1 — was a phantom field defined in the schema and passed to company research, but had no UI anywhere, so non-pilot users could never set it.
- **firstName/lastName now persisted** via `updateProfile` during onboarding submit — was collected at Step 0 but never saved (lines had a placeholder comment, no actual mutation call).
- **`scope` and `jobDescription` wired into plan prompt** — `buildUserContext` previously omitted both even when present. Scope is arguably the single highest-signal field after role title.
- **Stakeholders now injected into plan prompt** — `buildUserContext` previously read only from `onboardingData` and ignored the stakeholders table, so the AI had zero knowledge of specific people. Activities now reference real stakeholders by name.
- **Company research enriched** with `selectedGoals`, `existingContext`, `challenges`, `successDefinition` (previously missing from `companyResearchUserPrompt`).
- **`companyResearchJobs.inputSnapshot` expanded** with `experienceYears`, `teamSize`, `isNewTeam`, `workModel`, `reportsTo` so change-detection can trigger re-research when meaningful inputs shift.

### Post-onboarding editing (commit 2)
- **`onboarding.updateContext` mutation** — patches the safe editable subset (scope, reportsTo, successDefinition, existingContext, challenges, jobDescription). Structural fields (STARS, company, start date) remain frozen since editing them would invalidate the generated plan.
- **New "Plan context" section** on Settings → Profile tab with all 6 editable fields. Matches the save/saved/error UX pattern of other settings cards.
- Edits flow into every subsequent plan regeneration and company research run via `buildUserContext` / `companyResearchUserPrompt`.

Why this matters: before these changes, if onboarding data was wrong (like the pilot's mismatched role), there was no way to correct it without direct DB access, and the bad data poisoned every plan generation, company research run, and plan export forever.

## Test plan

- [ ] Complete onboarding as a new user, enter a value in the new "Describe your role scope" field at Step 1, submit, then inspect `onboardingData` — scope persists.
- [ ] Complete onboarding with first/last name filled — `users.name` is set on the user row.
- [ ] With 3+ stakeholders entered during onboarding, generate a plan and check that at least some generated activities reference specific stakeholder names (not generic "meet your manager").
- [ ] Navigate to Settings → Profile after onboarding, edit the Plan context fields, save, then regenerate the plan — verify the new context appears in the generated output.
- [ ] Run `resetAndReseed` as pilot — verify `roleTitle` = "Staff Product Designer", `roleType` = "Design", and all 6 optional onboarding fields are populated.
- [ ] Trigger company research manually, then query `companyResearchJobs` — verify `inputSnapshot` contains the new fields (experienceYears, teamSize, isNewTeam, workModel, reportsTo).
- [ ] Check that the schema migration doesn't break existing `companyResearchJobs` rows (new fields are all `v.optional`).

https://claude.ai/code/session_01Lpq9rXLwsVzA54dVoE2XdX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan Context editor allows updating role scope, goals, challenges, and success definition after onboarding
  * Role scope field added to onboarding to capture role context details
  * AI planning now incorporates stakeholder information and additional onboarding context for improved recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->