### PR TITLE
Add back-to-home navigation link to auth layout

### DIFF
--- a/src/app/(auth)/layout.js
+++ b/src/app/(auth)/layout.js
@@ -1,7 +1,30 @@
+import Link from "next/link";
+
 export default function AuthLayout({ children }) {
   return (
     <div className="min-h-screen bg-[#F5F2E8] flex items-center justify-center p-4">
       <div className="w-full max-w-md">
+        <div className="mb-6">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M19 12H5M12 5l-7 7 7 7" />
+            </svg>
+            Back to home
+          </Link>
+        </div>
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary
Added a "Back to home" navigation link to the authentication layout, allowing users to easily return to the homepage from any auth page (login, signup, etc.).

## Changes
- Imported Next.js `Link` component for client-side navigation
- Added a navigation section at the top of the auth layout with a back arrow icon and "Back to home" text
- Styled the link with hover effects and proper spacing (mb-6 margin bottom)
- Used an inline SVG arrow icon (pointing left) for visual clarity
- Applied responsive text styling with gray color scheme that darkens on hover

## Implementation Details
- The link is positioned above the `{children}` content, making it the first interactive element users see
- Uses Tailwind CSS classes for styling and responsive design
- SVG icon is inline for better performance and no additional HTTP requests
- Hover state provides visual feedback with `transition-colors` for smooth UX

https://claude.ai/code/session_01SES9UCAyKMekS7s7YkxUcM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Back to home" navigation link with an icon at the top of authentication pages, allowing users to quickly return to the main application homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->