### PR TITLE
Handle server errors gracefully in password reset flow

### DIFF
--- a/src/app/(auth)/reset-password/page.js
+++ b/src/app/(auth)/reset-password/page.js
@@ -56,7 +56,10 @@ function ResetPasswordInner() {
     } catch (err) {
       const message = err?.data ?? err?.message ?? "";
       setError(
-        message && typeof message === "string" && !/unauthenticated/i.test(message)
+        message &&
+        typeof message === "string" &&
+        !/unauthenticated/i.test(message) &&
+        !/server error/i.test(message)
           ? message
           : "That code didn't work. Check for typos or request a new one."
       );


### PR DESCRIPTION
## Summary
Updated the error handling logic in the password reset page to suppress generic server error messages and show a user-friendly fallback message instead.

## Key Changes
- Modified the error message validation condition to also filter out messages matching `/server error/i`
- This prevents exposing raw server error messages to users during the password reset process
- Users will now see the helpful fallback message ("That code didn't work. Check for typos or request a new one.") when server errors occur, rather than technical error details

## Implementation Details
The change adds an additional regex test to the existing error message validation chain. The condition now checks that the error message:
1. Exists and is a string
2. Does not contain "unauthenticated" (existing behavior)
3. Does not contain "server error" (new behavior)

Only when all conditions are met will the raw error message be displayed; otherwise, the user-friendly fallback message is shown.

https://claude.ai/code/session_017wMGv6HWojFy1YhebmoWCx