### PR TITLE
chore(seed): refresh pilot data with Algolia interview seed

### DIFF
--- a/convex/seed.js
+++ b/convex/seed.js
@@ -45,8 +45,40 @@ async function _reconcilePilotSchedule(ctx, userId) {
   };
 }
 
+// Map activity priority labels in the source seed (Must/Should) to the
+// High/Medium/Low scale the rest of the app uses for filtering and styling.
+function _activityPriority(p) {
+  if (p === "Must") return "High";
+  if (p === "Should") return "Medium";
+  if (p === "Could" || p === "Nice") return "Low";
+  return p; // already High/Medium/Low — pass through
+}
+
 async function _seedPlanData(ctx, userId) {
   const startDate = PILOT_PLAN_START_DATE;
+
+  const onboarding = {
+    roleTitle: "Staff Product Designer",
+    startDate,
+    experienceYears: 14,
+    isFirstRoleAtLevel: true,
+    roleType: "IC",
+    function_: "Design",
+    isNewTeam: false,
+    scope: "Sole designer for Agent Studio. Embedded across Agent Studio, MCP, and Frontend Experience teams. Responsible for dashboard configuration, AI behaviour patterns (trust, guardrails, explainability), and downstream frontend experiences.",
+    companyName: "Algolia",
+    companySize: "Growth",
+    companyStage: "Scaling",
+    workModel: "Remote",
+    industry: "AI / Developer Tools / Search & Discovery",
+    starsSituation: "AcceleratedGrowth",
+    reportsTo: "Director, User Experience (Jess Shutt — interim, pending new design leader hire)",
+    selectedGoals: ["relationships", "product_landscape", "quick_win"],
+    successDefinition: "North star: Algolia is simple to use, works out of the box, and less engagement is a success signal because the product does the work. Personally over the first 90 days: ship a UX audit shared across all teams, align with Kim on agent consistency vs divergence, ship one design improvement to beta customers with measured result, run an AI prototyping session for the design team, and propose a strategic dashboard or agent UX initiative.",
+    existingContext: "Algolia is a search-as-a-service company expanding into AI agents; Agent Studio is the new pillar (the business bet) that may eventually replace classic search with an agentic experience. Sole designer for Agent Studio, embedded across Agent Studio, MCP, and Frontend Experience teams. Two PMs (Imogen on Frontend/MCP, Peter on the Agent Studio backend pillar) and three engineering teams. Reports to Jess Shutt (Director, UX) on an interim basis — a new design leader will be hired in the first 90 days. Design team is 6 designers, under-resourced, in an explicit AI experimentation phase (no locked-in process; Jess's hard rule is everything must be shareable and commentable). No A/B testing yet — qualitative interviews with design partners and Hex analytics dominate. Research is democratized through Confluence and Research Ops; Zen leads AI research. Tools: Figma, Claude Code, Cursor (about half the team), GitHub, Vercel for staging prototypes, Loom, Confluence (lots of noise).",
+    challenges: "Sole designer across 3 teams — scope creep is guaranteed; need to agree explicit time allocation with Imogen and Peter and revisit monthly. Leadership vacuum: no permanent design manager, Jess is supportive but won't give design direction; lean on Duncan as principal-level sounding board and over-document decisions for the incoming leader. Peter operates like a CEO not an IC PM — be direct, move fast, don't wait for written briefs. Many stakeholders want involvement in Agent Studio — establish an async update channel (Slack/Loom/Confluence) by week 5. Team is behind on AI adoption and Jess has explicitly named me thought leader for AI in design workflow. No A/B testing capability — must rely on qualitative validation, Hex funnels, and staging prototypes for design partners. Confluence and Slack noise — target the signal via Zen and the PMs. Backend A/B test variants may pollute audit findings — confirm active experiments before evaluating any surface.",
+    jobDescription: "Staff Product Designer — Agent Studio (Algolia, Remote, London/EMEA). Sole designer responsible for the dashboard configuration experience for Agent Studio, AI behaviour patterns (trust, guardrails, explainability), and downstream frontend experiences. Embedded across Agent Studio (backend pillar), MCP, and Frontend Experience teams. Partners with PMs Imogen (Frontend/MCP) and Peter (pillar lead, ex-CEO), three engineering teams (Yousef leads Dashboard EM), Lead Researcher Zen on AI, and the wider 6-person design team led on an interim basis by Director of UX Jess Shutt. Connect dashboard configuration to downstream customer outcomes; run UX audits, build agent UX patterns that work for both customer-facing Agent Studio and internal optimization/productivity agents (alignment with Kim is an explicit success measure), and propose strategic initiatives such as a greenfield dashboard reinvention. Tools: Figma + Claude Code + GitHub + Vercel staging; Hex analytics; Confluence/Slack/Loom for shareable artifacts. Compensation: £125,000 base + 10% bonus + £5,000 signing + 5,139 stock options (4-year vest, 1-year cliff). 3-month probation extendable to 6. Remote with optional London office and Paris engineering visits.",
+  };
 
   const onboardingRow = await ctx.db
     .query("onboardingData")
@@ -54,32 +86,9 @@ async function _seedPlanData(ctx, userId) {
     .first();
 
   if (!onboardingRow) {
-    await ctx.db.insert("onboardingData", {
-      userId,
-      roleTitle: "Staff Product Designer",
-      startDate,
-      experienceYears: 8,
-      isFirstRoleAtLevel: false,
-      roleType: "Design",
-      function_: "Product Design / Agent Studio",
-      teamSize: 12,
-      isNewTeam: true,
-      scope: "Leading product design for Agent Studio, defining design direction and interaction patterns for AI agent interfaces",
-      companyName: "Algolia",
-      companySize: "500-1000",
-      companyStage: "Growth",
-      workModel: "Hybrid",
-      industry: "Technology / SaaS",
-      starsSituation: "Turnaround",
-      reportsTo: "Imogen Chen, VP of Product",
-      selectedGoals: ["relationships", "product_landscape", "quick_win"],
-      successDefinition: "Have a clear design vision for Agent Studio, establish design patterns the team trusts, deliver one high-impact design that ships, and build strong relationships with engineering and PM partners.",
-      existingContext: "Algolia is a search-as-a-service company expanding into AI agents. Agent Studio is a newer product surface. The design function has been engineering-led — previous design decisions were ad-hoc from PMs and engineers. The team recently shipped a major dashboard redesign.",
-      challenges: "The previous designer left 4 months ago and the team has been operating without dedicated design leadership. Some stakeholders are used to making design decisions themselves — I need to earn trust and demonstrate the value of design-led processes quickly. The product roadmap is engineering-driven.",
-      jobDescription: "Staff Product Designer — Agent Studio. You will own the end-to-end design for Algolia's Agent Studio product, from user research through high-fidelity prototypes and design system contributions. Partner with PM and Engineering to define the interaction model for AI agent configuration, testing, and deployment. Establish design patterns, run usability studies, and mentor junior designers. Requires 7+ years of product design experience, strong systems thinking, and experience designing developer tools or AI-powered interfaces.",
-    });
+    await ctx.db.insert("onboardingData", { userId, ...onboarding });
   } else {
-    await ctx.db.patch(onboardingRow._id, { startDate });
+    await ctx.db.patch(onboardingRow._id, onboarding);
   }
 
   const planId = await ctx.db.insert("plans", {
@@ -89,9 +98,9 @@ async function _seedPlanData(ctx, userId) {
   });
 
   const phaseData = [
-    { number: 1, name: "Learn", startDay: 1, endDay: 30, milestone: "Complete stakeholder mapping and understand product landscape", status: "active" },
-    { number: 2, name: "Contribute", startDay: 31, endDay: 60, milestone: "Deliver first research insights and establish credibility", status: "upcoming" },
-    { number: 3, name: "Lead", startDay: 61, endDay: 90, milestone: "Own research roadmap and influence product strategy", status: "upcoming" },
+    { number: 1, name: "LEARN", startDay: 1, endDay: 30, milestone: "UX Audit shared with all teams. Kim alignment framework drafted. Every key stakeholder has had a 1:1. Can explain Agent Studio architecture without notes.", status: "active" },
+    { number: 2, name: "SHIP", startDay: 31, endDay: 60, milestone: "One design improvement shipped to beta customers with measured result. AI prototyping session delivered. Stakeholder communication rhythm established. Shared definition of AI success for design team drafted.", status: "upcoming" },
+    { number: 3, name: "LEAD", startDay: 61, endDay: 90, milestone: "Strategic initiative proposed and discussed at leadership level. Agent UX patterns documented. New design leader relationship established. 90-day reflection shared.", status: "upcoming" },
   ];
 
   const phaseIds = [];
@@ -100,19 +109,20 @@ async function _seedPlanData(ctx, userId) {
     phaseIds.push(id);
   }
 
+  // weekIndex 0..11 — phase index 0..2 — theme + reflection prompt.
   const weekThemes = [
-    { number: 1, phase: 0, theme: "Orientation & Setup", prompt: "What surprised you most about your first week?" },
-    { number: 2, phase: 0, theme: "Context & Architecture", prompt: "What patterns are you noticing in how the team works?" },
-    { number: 3, phase: 0, theme: "Stakeholder Deep Dives", prompt: "Which relationships feel most important to develop?" },
-    { number: 4, phase: 0, theme: "User & Market Understanding", prompt: "What do users struggle with that the team doesn't see?" },
-    { number: 5, phase: 1, theme: "Quick Wins & First Contributions", prompt: "Where can you add the most value right now?" },
-    { number: 6, phase: 1, theme: "Research Framework", prompt: "What research methods are best suited for this team?" },
-    { number: 7, phase: 1, theme: "Process Improvements", prompt: "What processes could be made more efficient?" },
-    { number: 8, phase: 1, theme: "Broadening Impact", prompt: "How can your work influence decisions beyond your team?" },
-    { number: 9, phase: 2, theme: "Strategic Initiatives", prompt: "What's your vision for research at this company?" },
-    { number: 10, phase: 2, theme: "Mentoring & Growth", prompt: "How can you help others grow their research skills?" },
-    { number: 11, phase: 2, theme: "Roadmap Influence", prompt: "What should the product roadmap prioritize based on your research?" },
-    { number: 12, phase: 2, theme: "Reflection & Next Quarter", prompt: "What would you do differently if you started again?" },
+    { number: 1, phase: 0, theme: "People & Product", prompt: "What did I learn about the product or team today that I didn't know yesterday?" },
+    { number: 2, phase: 0, theme: "Team Integration & Listening", prompt: "What surprised me this week about how the team works?" },
+    { number: 3, phase: 0, theme: "Audit & Synthesis", prompt: "What friction point did I observe today that connects to what customers have told us?" },
+    { number: 4, phase: 0, theme: "Share & Align", prompt: "How did people react to my audit findings? What resonated? What surprised them?" },
+    { number: 5, phase: 1, theme: "Pick & Scope Quick Win", prompt: "What design decision did I make today? What was the reasoning?" },
+    { number: 6, phase: 1, theme: "Design & Validate", prompt: "What feedback changed my design direction today?" },
+    { number: 7, phase: 1, theme: "Build & Ship", prompt: "What did I ship or unblock today?" },
+    { number: 8, phase: 1, theme: "Measure & Document", prompt: "What would I do differently if I started this project over?" },
+    { number: 9, phase: 2, theme: "Strategic Thinking", prompt: "What pattern am I seeing across the product that nobody has connected yet?" },
+    { number: 10, phase: 2, theme: "Build Coalition", prompt: "Who did I bring along on the journey today? Who am I missing?" },
+    { number: 11, phase: 2, theme: "Present & Begin", prompt: "If I had to describe my biggest contribution so far in one sentence, what would it be?" },
+    { number: 12, phase: 2, theme: "Reflect & Plan", prompt: "What would I tell someone starting this role tomorrow?" },
   ];
 
   const weekIds = [];
@@ -135,66 +145,126 @@ async function _seedPlanData(ctx, userId) {
     weekIds.push(id);
   }
 
+  // ── Stakeholders ──────────────────────────────────────────────────────
+  // Insert first so activities can reference relatedStakeholderId. The
+  // "key" string is only used to wire activities → stakeholders below; it
+  // is not persisted.
+  const stakeholderData = [
+    { key: "jess", name: "Jess Shutt", role: "Director, User Experience (Interim Design Lead)", type: "Manager", priority: "Must", scheduled: true, firstDate: "2026-04-14", cadenceDays: 7, bg: "Interim manager. Leads Research & Insights. Not a design expert, won't second-guess design decisions. Outcomes-focused: 'I don't care how you got there, I care that you deliver.' Will point out political blockers and leadership opportunities. Previously at Salesforce (ML research) and Twilio. Two success measures: (1) align with Kim on agent consistency vs divergence, (2) manage stakeholder interest while moving fast. Prefers 1:1s focused on real problems, not status updates. Hates wasted face time — don't give status updates, discuss real blockers and stakeholder challenges. Weekly 1:1 for first month, then every other week. You'll have an onboarding buddy. Encouraging you to push the envelope on AI in design workflow. Said 'you've gone farther with AI than most of the team' and wants you as thought leader for AI adoption. Team is in explicit experimentation phase with AI — no process locked in yet. Jess's rule: everything must be shareable and commentable. Team ceremonies: design studio (crit, twice weekly), team meetings, monthly retros. Jess not your long-term boss — will hire a new design leader and you may have input on that hire. Stephen (new CEO) in third week, still learning. Jess said Peter (PM) operates like a CEO and sometimes forgets PM responsibilities — manage accordingly." },
+    { key: "imogen", name: "Imogen", role: "PM, Frontend/MCP", type: "CrossFunctional", priority: "Must", scheduled: true, firstDate: "2026-03-28", cadenceDays: 7, bg: "Met during Cross-Functional Collaboration interview. Owns frontend experience: how dashboard config translates into customer-facing experiences. Also owns MCP (connecting Algolia data to external agents). SKI tool funnels users into Agent Studio. Team not doing A/B testing yet due to scale — qualitative interviews with design partners instead. Previous designer left. She described the org: 2 PMs (her + Peter), 3 eng teams, designer works across all. Mentioned internal eval framework for latency/relevancy/ranking. Positive interview, engaged throughout." },
+    { key: "peter", name: "Peter", role: "PM, Backend Agent Studio (Pillar Lead)", type: "CrossFunctional", priority: "Must", scheduled: false, bg: "Haven't met yet. Leads the Agent Studio pillar (business bet). Former founder/CEO multiple times, first IC PM role in a long time. Jess warned: operates like a CEO, sometimes forgets to write things down because he's used to having a team under him. Will have strong opinions and move fast. London-based — good for in-person meetings. Need to understand his priorities in first 2 days. Expect directness and speed from him." },
+    { key: "yousef", name: "Yousef", role: "Engineering Manager, Dashboard", type: "CrossFunctional", priority: "Must", scheduled: true, firstDate: "2026-04-02", cadenceDays: 7, bg: "Met during Ownership interview. 8 years at Algolia. Dashboard team works closely with Agent Studio. Layered API philosophy: visual layer, business logic, primitives. Values data-driven design. His team runs their own analytics using Hex. Doesn't need embedded data science — engineers handle it. Said 'less engagement = success' as a metric. Excited about John's coding background. Will appreciate specs that reduce engineering ambiguity." },
+    { key: "duncan", name: "Duncan", role: "Principal Product Designer", type: "Peer", priority: "Must", scheduled: true, firstDate: "2026-03-31", bg: "Met during UX Craft interview. 3.5 years at Algolia. Built Merch Studio. Currently 'floaty designer' helping across teams. Based in London. Previously at Twilio (like Jess). Said 'this is awesome' about the Sandbox prototype. Adapted his interview around it. Team is 6 designers, under-resourced. Design needs to 'find a voice and influence.' Main Algolia problem: too much indexing on developer persona, not enough for low-code users. Team trying to integrate Claude Code. Wants Agent Studio to grow beyond chatbots into workflow agents. Key ally at principal level." },
+    { key: "kim", name: "Kim", role: "Product Designer, Optimization / Agent Studio (Productivity)", type: "Peer", priority: "Must", scheduled: false, bg: "Met during panel round. Works on optimization and productivity agents (internal-facing). Under the 'optimize' team. Jess's explicit success measure: align with Kim on when agent patterns should be consistent vs different. Currently defaulting to consistency for consistency's sake — Jess says 'that's a bad answer.' Different audiences (customer-facing vs internal productivity) need different patterns even though they have slightly different audiences. Kim builds her own funnel dashboards using Hex. Early 1:1 critical — week 1-2. Jess said both your EMs (Kim's and yours) are 'really really strong in terms of how they partner with design.'" },
+    { key: "etienne", name: "Etienne Martin", role: "VP Product", type: "SkipLevel", priority: "Should", scheduled: true, firstDate: "2026-04-02", cadenceDays: 90, bg: "Met during VP interview. Sets the vision. Wants: dashboard reinvention ('greenfield'), 'works out of the box', design participating earlier in problem definition. Agent Studio defensive posture: search may be replaced by agentic experience. Next 6 months: nail core. 12 months: new use cases and revenue lines. Success metric: 'Algolia is simple to use.' Less engagement = product working. New CEO joined same week." },
+    { key: "zen", name: "Zen", role: "Lead User Researcher, AI/Agent Studio", type: "CrossFunctional", priority: "Must", scheduled: false, bg: "From Jess's call. Lead researcher for AI. Agent Studio is their home team but they move between spaces more flexibly than designers do. About to focus on data quality blocker: customers think their data is too bad for AI (often not true — sometimes AI can clean it, sometimes they just need to add events). This research directly impacts Agent Studio adoption. Also was primary researcher for all genAI features (genAI toolkit, comparison tables, recommended queries). Key partner for UX audit and customer insights. Research data is on Confluence, almost all public (PII scrubbed). No embedded data science on your team — engineers run their own analytics via Hex. Research is democratized: you're encouraged to run your own research, research ops will support. Connect with Zen in week 1." },
+    { key: "robin", name: "Robin", role: "Head of Growth", type: "CrossFunctional", priority: "Should", scheduled: false, bg: "From Jess's call. Former designer turned Head of Growth. Owns biggest customer population (freemium). Very experimentation-minded. Has most data about customer behaviour. Jess said 'you'll probably see him a lot' and 'we love hanging out with him, he's a very smart dude.' Good source of customer data and experiment patterns even though Agent Studio is paid product. Your work won't be directly in his space but he has the data you'll need." },
+    { key: "tanya", name: "Tanya", role: "PM (Growth, on loan to Agent Studio)", type: "CrossFunctional", priority: "Should", scheduled: false, bg: "From Jess's call. Technically on Growth but on loan to Agent Studio. May work with you or with Chloe (new growth designer). Understand her scope early." },
+    { key: "chloe", name: "Chloe", role: "Product Designer, Growth (New Hire)", type: "Peer", priority: "Could", scheduled: false, bg: "From Jess's call. Just hired for Growth. Another new joiner. Could be an onboarding ally." },
+    { key: "new_design_leader", name: "TBD (New Design Leader)", role: "Replacing James as Design Manager", type: "Manager", priority: "Must", scheduled: false, bg: "Will be hired during first 90 days. Jess said 'hopefully you'll have a say in who your next boss is.' Your 90-day work becomes the foundation of this relationship. Make it excellent. Document decisions clearly so the new leader can understand your rationale when they arrive." },
+  ];
+
+  const stakeholderIdByKey = {};
+  for (const s of stakeholderData) {
+    const id = await ctx.db.insert("stakeholders", {
+      userId,
+      name: s.name,
+      role: s.role,
+      relationshipType: s.type,
+      priority: s.priority,
+      backgroundContext: s.bg,
+      firstMeetingScheduled: !!s.scheduled,
+      ...(s.firstDate ? { firstMeetingDate: s.firstDate } : {}),
+      ...(s.cadenceDays ? { cadenceDays: s.cadenceDays } : {}),
+      workingPreferences: [],
+    });
+    stakeholderIdByKey[s.key] = id;
+  }
+
+  // ── Activities ────────────────────────────────────────────────────────
+  // weekIndex is 0-based (matches weekIds and weekThemes). day is 1..90.
   const activities = [
-    { week: 0, day: 1, title: "Complete HR onboarding and system setup", desc: "Finish all administrative setup: badge, laptop, Slack, email, tool access.", cat: "learning", time: "4h", priority: "High" },
-    { week: 0, day: 1, title: "Meet your direct manager", desc: "30-min intro with your manager. Align on first-week expectations and communication preferences.", cat: "relationships", time: "30m", priority: "High" },
-    { week: 0, day: 2, title: "Review product documentation", desc: "Read through product docs, PRDs, and recent research reports to understand the current state.", cat: "learning", time: "3h", priority: "High" },
-    { week: 0, day: 2, title: "Set up research tools", desc: "Get access to user research tools (UserTesting, Maze, analytics dashboards).", cat: "learning", time: "1h", priority: "Medium" },
-    { week: 0, day: 3, title: "Attend team standup", desc: "Join the daily standup to observe team dynamics and current priorities.", cat: "learning", time: "15m", priority: "Medium" },
-    { week: 0, day: 3, title: "1:1 with product lead", desc: "Meet with the product lead to understand product vision and research needs.", cat: "relationships", time: "45m", priority: "High" },
-    { week: 0, day: 4, title: "Shadow a user research session", desc: "Observe an existing research session or watch recent recordings.", cat: "learning", time: "2h", priority: "Medium" },
-    { week: 0, day: 4, title: "Draft stakeholder map", desc: "Create initial stakeholder map identifying key people and their influence/interest.", cat: "shipping", time: "1h", priority: "High" },
-    { week: 0, day: 5, title: "Write first-week reflection", desc: "Document key observations, questions, and initial hypotheses from week 1.", cat: "learning", time: "30m", priority: "Medium" },
-    { week: 0, day: 5, title: "Plan week 2 priorities", desc: "Set specific goals for next week based on what you've learned.", cat: "shipping", time: "30m", priority: "Medium" },
-    { week: 1, day: 8, title: "Deep dive into search architecture", desc: "Meet with engineering to understand search infrastructure, relevance models, and data flow.", cat: "learning", time: "2h", priority: "High" },
-    { week: 1, day: 8, title: "Review analytics dashboards", desc: "Study key metrics: search usage, click-through rates, query patterns, and conversion.", cat: "learning", time: "1.5h", priority: "High" },
-    { week: 1, day: 9, title: "Meet design team lead", desc: "Understand design process, how research currently feeds into design decisions.", cat: "relationships", time: "45m", priority: "High" },
-    { week: 1, day: 9, title: "Audit existing research repository", desc: "Review past research studies, findings, and how they were actioned.", cat: "learning", time: "2h", priority: "Medium" },
-    { week: 1, day: 10, title: "Attend product planning session", desc: "Observe how product decisions are made and where research could add value.", cat: "learning", time: "1h", priority: "Medium" },
-    { week: 1, day: 11, title: "1:1 with customer success lead", desc: "Learn about common customer pain points and feature requests from CS perspective.", cat: "relationships", time: "45m", priority: "Medium" },
-    { week: 1, day: 12, title: "Map current user journey", desc: "Document the end-to-end search experience from user perspective.", cat: "shipping", time: "3h", priority: "High" },
-    { week: 2, day: 15, title: "1:1 with VP of Product", desc: "Understand strategic priorities and how research should align with product roadmap.", cat: "relationships", time: "45m", priority: "High" },
-    { week: 2, day: 15, title: "Lunch with engineering team", desc: "Build informal relationships with engineers you'll collaborate with.", cat: "relationships", time: "1h", priority: "Medium" },
-    { week: 2, day: 16, title: "Meet sales team lead", desc: "Understand how customers describe their needs during sales conversations.", cat: "relationships", time: "45m", priority: "Medium" },
-    { week: 2, day: 17, title: "Draft research roadmap v1", desc: "Based on stakeholder input, draft initial research priorities for next 60 days.", cat: "shipping", time: "3h", priority: "High" },
-    { week: 2, day: 18, title: "Present learnings to team", desc: "Share a brief summary of your first 2.5 weeks of observations with the team.", cat: "influence", time: "1h", priority: "High" },
-    { week: 2, day: 19, title: "Identify quick-win research opportunity", desc: "Find a small research question that can be answered quickly with high impact.", cat: "shipping", time: "1h", priority: "High" },
-    { week: 3, day: 22, title: "Competitive analysis", desc: "Analyze 3-5 competitors' search experiences and document differentiators.", cat: "learning", time: "4h", priority: "Medium" },
-    { week: 3, day: 23, title: "Conduct first user interview", desc: "Run your first user interview focused on search pain points.", cat: "shipping", time: "2h", priority: "High" },
-    { week: 3, day: 24, title: "Analyze support tickets", desc: "Review recent support tickets related to search to identify patterns.", cat: "learning", time: "2h", priority: "Medium" },
-    { week: 3, day: 25, title: "Synthesize Phase 1 findings", desc: "Create a summary document of all learnings from the first 30 days.", cat: "shipping", time: "3h", priority: "High" },
-    { week: 3, day: 26, title: "Phase 1 review with manager", desc: "Present your 30-day findings and get alignment on Phase 2 priorities.", cat: "relationships", time: "1h", priority: "High" },
-    { week: 4, day: 29, title: "Launch quick-win research study", desc: "Execute the small research study identified in week 3.", cat: "shipping", time: "4h", priority: "High" },
-    { week: 4, day: 30, title: "Share quick-win findings", desc: "Present research findings to stakeholders with actionable recommendations.", cat: "influence", time: "1h", priority: "High" },
-    { week: 4, day: 31, title: "Establish research ops rhythm", desc: "Set up regular cadence for research activities: participant recruitment, synthesis sessions.", cat: "shipping", time: "2h", priority: "Medium" },
-    { week: 4, day: 32, title: "Create research templates", desc: "Build reusable templates for interview guides, synthesis docs, and reports.", cat: "shipping", time: "3h", priority: "Medium" },
-    { week: 4, day: 33, title: "Coffee chat with cross-team PM", desc: "Build relationship with a PM from another team to expand influence.", cat: "relationships", time: "30m", priority: "Low" },
-    { week: 5, day: 36, title: "Design usability study", desc: "Plan and design a usability study for a key search feature.", cat: "shipping", time: "4h", priority: "High" },
-    { week: 5, day: 37, title: "Recruit research participants", desc: "Identify and schedule participants for upcoming studies.", cat: "shipping", time: "2h", priority: "High" },
-    { week: 5, day: 38, title: "Run first usability sessions", desc: "Conduct 3-5 usability sessions and capture findings.", cat: "shipping", time: "5h", priority: "High" },
-    { week: 5, day: 39, title: "Synthesize usability findings", desc: "Analyze recordings and notes, create a findings report.", cat: "shipping", time: "3h", priority: "High" },
-    { week: 5, day: 40, title: "Present to design team", desc: "Share usability findings and recommendations with the design team.", cat: "influence", time: "1h", priority: "High" },
-    { week: 6, day: 43, title: "Propose research-into-design process", desc: "Draft a process for how research findings flow into design decisions.", cat: "influence", time: "2h", priority: "High" },
-    { week: 6, day: 44, title: "Set up research repository", desc: "Create a centralized place for research findings accessible to all teams.", cat: "shipping", time: "3h", priority: "Medium" },
-    { week: 6, day: 45, title: "Mid-quarter check-in with manager", desc: "Review progress against goals and adjust priorities.", cat: "relationships", time: "1h", priority: "High" },
-    { week: 6, day: 46, title: "Train team on research methods", desc: "Run a short workshop on basic research methods for PMs and designers.", cat: "influence", time: "2h", priority: "Medium" },
-    { week: 7, day: 50, title: "Cross-team research presentation", desc: "Present key findings to a broader audience beyond your immediate team.", cat: "influence", time: "1.5h", priority: "High" },
-    { week: 7, day: 51, title: "Identify strategic research initiative", desc: "Scope a larger research project that addresses a strategic product question.", cat: "shipping", time: "3h", priority: "High" },
-    { week: 7, day: 52, title: "1:1 with engineering lead", desc: "Discuss how research can better inform technical decisions.", cat: "relationships", time: "45m", priority: "Medium" },
-    { week: 7, day: 53, title: "Phase 2 review with manager", desc: "Present 60-day accomplishments and align on Phase 3 strategy.", cat: "relationships", time: "1h", priority: "High" },
-    { week: 8, day: 57, title: "Launch strategic research project", desc: "Kick off the larger research initiative identified in week 8.", cat: "shipping", time: "5h", priority: "High" },
-    { week: 8, day: 58, title: "Build research advisory group", desc: "Form a small group of stakeholders who review and prioritize research.", cat: "influence", time: "1h", priority: "Medium" },
-    { week: 8, day: 59, title: "Write research insights newsletter", desc: "Start a regular digest of research insights for the broader org.", cat: "influence", time: "1h", priority: "Medium" },
-    { week: 9, day: 64, title: "Mentor a junior team member", desc: "Set up regular mentoring sessions with a junior researcher or designer.", cat: "relationships", time: "1h", priority: "Medium" },
-    { week: 9, day: 65, title: "Document research playbook", desc: "Write up the research processes you've established as a team playbook.", cat: "shipping", time: "4h", priority: "Medium" },
-    { week: 9, day: 66, title: "Stakeholder feedback round", desc: "Gather feedback from key stakeholders on research impact so far.", cat: "relationships", time: "2h", priority: "High" },
-    { week: 10, day: 71, title: "Present research-informed roadmap input", desc: "Share research-backed recommendations for the next quarter's product roadmap.", cat: "influence", time: "2h", priority: "High" },
-    { week: 10, day: 72, title: "Finalize strategic research findings", desc: "Complete the strategic research project and prepare final report.", cat: "shipping", time: "5h", priority: "High" },
-    { week: 10, day: 73, title: "Share strategic findings company-wide", desc: "Present strategic research findings to leadership.", cat: "influence", time: "1h", priority: "High" },
-    { week: 11, day: 78, title: "Write 90-day self-assessment", desc: "Document accomplishments, impact, relationships built, and areas for growth.", cat: "learning", time: "2h", priority: "High" },
-    { week: 11, day: 79, title: "90-day review with manager", desc: "Formal review of your first 90 days, goals met, and next-quarter plan.", cat: "relationships", time: "1h", priority: "High" },
-    { week: 11, day: 80, title: "Plan next quarter goals", desc: "Set goals for the next quarter based on 90-day learnings.", cat: "shipping", time: "2h", priority: "High" },
-    { week: 11, day: 80, title: "Thank key stakeholders", desc: "Send personalized thank-you notes to people who helped during onboarding.", cat: "relationships", time: "30m", priority: "Medium" },
+    // Week 1 — People & Product
+    { week: 0, day: 1, title: "IT setup and tool access", desc: "Laptop arrives week before. Day 1: IT call, get logged into Slack, Figma, Confluence, Hex, email. Set up Claude Code and development environment on personal machine for side projects (separate from work).", cat: "learning", time: "2hr+", priority: "Must" },
+    { week: 0, day: 1, title: "1:1 with Jess (manager)", desc: "First formal 1:1. She'll give you an onboarding plan. Ask: what does success look like beyond what we discussed in the pre-start call? Any political dynamics I should know about? Who is my onboarding buddy?", cat: "relationships", time: "30min", priority: "Must", rel: "jess" },
+    { week: 0, day: 2, title: "1:1 with Imogen (PM, Frontend/MCP)", desc: "Deepen the relationship from interview. Ask: what's the most urgent product question you need design help with right now? What customer design partners should I talk to first?", cat: "relationships", time: "30min", priority: "Must", rel: "imogen" },
+    { week: 0, day: 2, title: "1:1 with Peter (PM, Pillar Lead)", desc: "First meeting. Critical. He's a former CEO adjusting to IC PM. Be direct. Ask: what are your top 3 priorities for Agent Studio this quarter? What does he need from design in the first month? Understand his working style.", cat: "relationships", time: "30min", priority: "Must", rel: "peter" },
+    { week: 0, day: 3, title: "1:1 with Yousef (EM, Dashboard)", desc: "Reconnect from interview. Ask: what's in the current sprint? What engineering capacity is available? How does his team prefer to receive design input? Get access to Hex dashboards.", cat: "relationships", time: "30min", priority: "Must", rel: "yousef" },
+    { week: 0, day: 3, title: "1:1 with Duncan (Principal Designer)", desc: "Reconnect from interview. Ask: what design patterns has the team explored for agent experiences? What's the design system state? How do design studio sessions work?", cat: "relationships", time: "30min", priority: "Must", rel: "duncan" },
+    { week: 0, day: 4, title: "1:1 with Kim (Designer, Optimization/Productivity)", desc: "Jess's explicit success measure. Ask: how are you currently approaching agent patterns? Where do you think consistency matters vs where should we diverge? What's working and what's frustrating?", cat: "relationships", time: "30min", priority: "Must", rel: "kim" },
+    { week: 0, day: 4, title: "1:1 with Zen (Lead Researcher, AI)", desc: "Understand current research landscape. Ask: what studies have been done on Agent Studio? What's the data quality blocker they're investigating? Where are the biggest open questions? Get access to all research on Confluence.", cat: "relationships", time: "30min", priority: "Must", rel: "zen" },
+    { week: 0, day: 5, title: "Full Agent Studio product walkthrough", desc: "Create 3+ agents using different templates and from scratch. Test MCP connections (Public and Productivity). Try the SKI tool. Time everything. Document every friction point. Screenshot everything.", cat: "learning", time: "2hr+", priority: "Must" },
+    { week: 0, day: 5, title: "Review existing Agent Studio design files in Figma", desc: "Understand what the previous designer built, what shipped, what's in progress, what was abandoned. Note design system components used and gaps.", cat: "learning", time: "1hr", priority: "Should" },
+
+    // Week 2 — Team Integration & Listening
+    { week: 1, day: 6, title: "Attend all standups (Agent Studio, MCP, Frontend Experience)", desc: "Just listen. Take notes. Understand sprint priorities, blockers, and team dynamics. Don't contribute yet.", cat: "learning", time: "30min", priority: "Must" },
+    { week: 1, day: 6, title: "Meet onboarding buddy", desc: "Jess mentioned you'll have one. Lean on them for cultural questions, tool tips, and navigating Confluence/Slack noise.", cat: "relationships", time: "30min", priority: "Should" },
+    { week: 1, day: 7, title: "Attend design studio session", desc: "Listen and give feedback on others' work. Don't present your own work yet. Show you're a thoughtful critic before you're a contributor.", cat: "relationships", time: "1hr", priority: "Must" },
+    { week: 1, day: 7, title: "Read all Agent Studio research on Confluence", desc: "Zen will point you to the right places. Read every customer interview transcript, research finding, and insight doc available. Take notes on patterns.", cat: "learning", time: "2hr+", priority: "Must" },
+    { week: 1, day: 8, title: "Explore the full Algolia dashboard beyond Agent Studio", desc: "Understand search configuration, analytics, indices, rules, merchandising. Agent Studio designs can't conflict with the rest of the platform.", cat: "learning", time: "2hr+", priority: "Should" },
+    { week: 1, day: 9, title: "Try competitor products", desc: "Voiceflow, Botpress, Amazon Bedrock Agents, LangChain. Note patterns that work and don't work. Build a lightweight competitive reference doc.", cat: "learning", time: "2hr+", priority: "Should" },
+    { week: 1, day: 10, title: "Review the internal eval framework", desc: "Imogen mentioned internal evals for latency, relevancy, ranking. Understand how it works. This connects to the LLM Leaderboard they just published and to your Sandbox concept.", cat: "learning", time: "1hr", priority: "Should" },
+    { week: 1, day: 10, title: "1:1 with Robin (Head of Growth)", desc: "Former designer. Owns biggest customer population. Experimentation-minded. Ask: what does he know about Agent Studio adoption? What data does his team have about customer behaviour?", cat: "relationships", time: "30min", priority: "Should", rel: "robin" },
+
+    // Week 3 — Audit & Synthesis
+    { week: 2, day: 11, title: "Start writing UX Audit document", desc: "Map the full Agent Studio journey: signup, first agent, configuration (prompt, tools, customisations, provider/model), testing (chat panel), publishing, analytics, conversations. Annotate friction points with screenshots.", cat: "learning", time: "2hr+", priority: "Must" },
+    { week: 2, day: 12, title: "Cross-reference audit with customer feedback", desc: "Match your friction points with what customers have said in research. Where do your observations align? Those are the highest-confidence problems.", cat: "learning", time: "1hr", priority: "Must" },
+    { week: 2, day: 13, title: "Document design system gaps for Agent Studio", desc: "What components exist? What's missing? What's inconsistent with the rest of the dashboard? Note where Kim's optimization patterns overlap or conflict.", cat: "learning", time: "1hr", priority: "Should" },
+    { week: 2, day: 13, title: "Attend second design studio session", desc: "Give useful feedback on at least one project. Reference something you learned from your audit. Start building your reputation as someone who sees the system.", cat: "relationships", time: "1hr", priority: "Must" },
+    { week: 2, day: 14, title: "Draft Kim alignment framework", desc: "Based on your audit and conversations with Kim, start documenting: which patterns should be shared (e.g., agent configuration basics) vs different (e.g., internal productivity agents don't need the same trust/guardrail patterns as customer-facing ones).", cat: "shipping", time: "1hr", priority: "Must", rel: "kim" },
+    { week: 2, day: 15, title: "Identify the configuration-to-outcome gap", desc: "The JD said 'connect dashboard configuration to downstream outcomes.' Map where this connection is weakest. This becomes the core of your Phase 2 quick win.", cat: "learning", time: "1hr", priority: "Must" },
+
+    // Week 4 — Share & Align
+    { week: 3, day: 16, title: "Present UX Audit in design studio", desc: "15 minutes max. Frame as 'fresh eyes findings.' Don't propose solutions. Diagnose. Ask for feedback. This is your first public contribution to the team.", cat: "influence", time: "1hr", priority: "Must" },
+    { week: 3, day: 17, title: "Share written audit with Imogen, Peter, and Yousef", desc: "Async via Confluence. Let them validate or challenge your observations. Ask: does this match what you're seeing?", cat: "influence", time: "30min", priority: "Must", rel: "imogen" },
+    { week: 3, day: 18, title: "Discuss research priorities with Zen", desc: "Which audit findings should become research questions? Which already have data? Where can Zen's upcoming data quality research inform your work?", cat: "relationships", time: "30min", priority: "Must", rel: "zen" },
+    { week: 3, day: 18, title: "Share Kim alignment framework draft with Kim and Jess", desc: "Get their input. Jess specifically asked for this. Kim's buy-in is essential. Frame as a starting point, not a final answer.", cat: "influence", time: "30min", priority: "Must", rel: "kim" },
+    { week: 3, day: 19, title: "Identify quick win candidates for Phase 2", desc: "From your audit, list 2-3 problems that meet the criteria: small enough to ship in 2-3 weeks, measurable, connected to customer pain. Discuss with Imogen before committing.", cat: "learning", time: "1hr", priority: "Must", rel: "imogen" },
+    { week: 3, day: 20, title: "Write 30-day reflection", desc: "What surprised you? What's harder than expected? What's the single biggest opportunity? Share with Jess in your 1:1. This feeds into the Phase 1 review.", cat: "learning", time: "30min", priority: "Must" },
+
+    // Week 5 — Pick & Scope Quick Win
+    { week: 4, day: 21, title: "Discuss quick win options with Imogen and Peter", desc: "Present 2-3 candidates from your audit. Let PMs help prioritise based on quarterly goals. Don't pick in isolation. The act of discussing options shows staff-level thinking.", cat: "shipping", time: "1hr", priority: "Must", rel: "imogen" },
+    { week: 4, day: 21, title: "Set up Agent Studio design Slack channel or async update", desc: "Jess's second success measure: manage stakeholder interest. Create an async mechanism to keep people informed. Post your first update: 'Here's what I'm working on this week.'", cat: "influence", time: "30min", priority: "Must" },
+    { week: 4, day: 22, title: "Write hypothesis for chosen quick win", desc: "'If we [change X], we expect [metric Y] to improve because [user insight from audit].' Define success criteria before designing.", cat: "shipping", time: "30min", priority: "Must" },
+    { week: 4, day: 23, title: "Begin design in Figma", desc: "Start with the team's existing design system. Use existing components where possible. Only create new components where genuinely needed.", cat: "shipping", time: "2hr+", priority: "Must" },
+
+    // Week 6 — Design & Validate
+    { week: 5, day: 26, title: "Build code prototype of quick win", desc: "Use Claude Code. Deploy to Vercel. This is your workflow in action. The prototype becomes a case study for the team.", cat: "shipping", time: "2hr+", priority: "Must" },
+    { week: 5, day: 27, title: "Run AI prototyping session in design studio", desc: "Jess explicitly wants this. Show your Claude Code + Figma MCP + GitHub + Vercel workflow. Live demo, not slides. Make it practical. Team is behind on AI adoption. You're the catalyst.", cat: "influence", time: "1hr", priority: "Must" },
+    { week: 5, day: 28, title: "Present design in design studio for peer feedback", desc: "Show Figma and code prototype. Get feedback from Duncan and Kim especially.", cat: "shipping", time: "1hr", priority: "Must" },
+    { week: 5, day: 29, title: "Test with 3-5 beta customers (design partners)", desc: "Imogen connects you to customer design partners. Qualitative validation since you don't have A/B test traffic. Use staging environment approach you discussed with Yousef.", cat: "shipping", time: "2hr+", priority: "Must", rel: "imogen" },
+
+    // Week 7 — Build & Ship
+    { week: 6, day: 31, title: "Work with engineering on build", desc: "Bring wireframes and code prototype. Weekly reviews. No handoff surprises. Speak Yousef's language: API schemas, state management, component reusability.", cat: "shipping", time: "2hr+", priority: "Must", rel: "yousef" },
+    { week: 6, day: 33, title: "Build staging version for customer testing", desc: "If applicable, host on Vercel. Customers test without affecting production. The approach you described to Yousef for limited traffic environments.", cat: "shipping", time: "2hr+", priority: "Should" },
+    { week: 6, day: 34, title: "Draft shared definition of AI success for design team", desc: "Jess flagged: no shared definition. Some say efficiency, some say fun. Draft a practical framework with 3-4 criteria. Share with Jess for input before presenting to team.", cat: "influence", time: "1hr", priority: "Should" },
+
+    // Week 8 — Measure & Document
+    { week: 7, day: 36, title: "Ship to beta customers", desc: "Coordinate with engineering on release. Monitor results using Hex analytics and qualitative feedback from design partners.", cat: "shipping", time: "1hr", priority: "Must" },
+    { week: 7, day: 38, title: "Document the full cycle", desc: "Hypothesis, design, what you tested, what happened, what you learned. This becomes your credibility deposit. Share on Confluence and Slack.", cat: "shipping", time: "1hr", priority: "Must" },
+    { week: 7, day: 39, title: "Start contributing to Agent Studio design system", desc: "If you created components for your quick win, document and share them. Contribute back.", cat: "influence", time: "1hr", priority: "Should" },
+    { week: 7, day: 40, title: "Write 60-day reflection", desc: "What you shipped, what worked, what you'd do differently. Relationship health check. Goal progress. Share with Jess.", cat: "learning", time: "30min", priority: "Must" },
+
+    // Week 9 — Strategic Thinking
+    { week: 8, day: 41, title: "Choose strategic initiative", desc: "Option A: Dashboard vision (Etienne's 'greenfield' brief). Option B: Agent UX pattern library (defining what good agent UX looks like for Algolia). Discuss with Jess and Duncan.", cat: "influence", time: "1hr", priority: "Must" },
+    { week: 8, day: 43, title: "Write initiative brief", desc: "One page: the problem, the opportunity, the approach, the timeline, what success looks like. Ground it in your audit findings and customer data.", cat: "influence", time: "2hr+", priority: "Must" },
+    { week: 8, day: 44, title: "Discuss brief with Imogen and Peter", desc: "Get PM input before presenting broadly. They'll flag priorities, constraints, and political dynamics.", cat: "influence", time: "30min", priority: "Must", rel: "imogen" },
+
+    // Week 10 — Build Coalition
+    { week: 9, day: 46, title: "Share brief with Yousef for engineering feasibility", desc: "Understand technical constraints and effort. Bring wireframes, not polished designs.", cat: "influence", time: "30min", priority: "Must", rel: "yousef" },
+    { week: 9, day: 47, title: "Share brief with Duncan for design perspective", desc: "He's principal level. His endorsement matters for the design org.", cat: "influence", time: "30min", priority: "Must", rel: "duncan" },
+    { week: 9, day: 49, title: "Incorporate feedback and refine", desc: "Update the brief based on all stakeholder input. Prepare a 10-minute design studio presentation.", cat: "influence", time: "1hr", priority: "Must" },
+
+    // Week 11 — Present & Begin
+    { week: 10, day: 51, title: "Present initiative in design studio", desc: "10-15 minutes. Show the opportunity, the approach, early explorations. Ask for feedback. This positions you as someone who sees beyond individual features.", cat: "influence", time: "1hr", priority: "Must" },
+    { week: 10, day: 52, title: "Share with Jess and leadership", desc: "Frame as: 'Here's what I've learned in 60 days, here's the biggest opportunity, here's how I'd approach it.' If new design leader has been hired, include them.", cat: "influence", time: "30min", priority: "Must", rel: "jess" },
+    { week: 10, day: 54, title: "Begin first sprint of initiative", desc: "Even if not formally prioritised, starting the exploration shows ownership. Adjust scope based on feedback.", cat: "shipping", time: "2hr+", priority: "Should" },
+
+    // Week 12 — Reflect & Plan
+    { week: 11, day: 56, title: "Write 90-day reflection", desc: "What you shipped, what you learned, relationships built, what you'd do differently, what you're proposing next. Comprehensive. This is your performance review foundation.", cat: "learning", time: "1hr", priority: "Must" },
+    { week: 11, day: 58, title: "Share 90-day reflection with Jess (or new design leader)", desc: "If new leader is in place, this is your introduction document. If still Jess, it's your probation evidence.", cat: "influence", time: "30min", priority: "Must", rel: "jess" },
+    { week: 11, day: 59, title: "Plan next quarter", desc: "Based on initiative brief feedback, quick win results, and team needs. Propose your own Q2 priorities. Staff level means you propose direction, you don't wait for it.", cat: "influence", time: "1hr", priority: "Must" },
+    { week: 11, day: 60, title: "Publish one piece of content about agent UX patterns", desc: "Internal or external. Could be a Confluence doc, a design studio talk, or a LinkedIn post. Share what you've learned about designing for AI agents. Position yourself as a thinker in this space.", cat: "influence", time: "1hr", priority: "Should" },
   ];
 
   for (const a of activities) {
@@ -207,7 +277,10 @@ async function _seedPlanData(ctx, userId) {
       description: a.desc,
       category: a.cat,
       estimatedTime: a.time,
-      priority: a.priority,
+      priority: _activityPriority(a.priority),
+      ...(a.rel && stakeholderIdByKey[a.rel]
+        ? { relatedStakeholderId: stakeholderIdByKey[a.rel] }
+        : {}),
       scheduledDate: scheduleYmd(startDate, a.day),
       scheduledDay: a.day,
       status: "upcoming",
@@ -216,38 +289,16 @@ async function _seedPlanData(ctx, userId) {
     });
   }
 
-  const stakeholderData = [
-    { name: "Imogen Chen", role: "VP of Product", type: "Champion", priority: "Must", stance: "Supportive", influence: "High", interest: "High", bg: "10+ years in search. Advocates for user-centric approach. Previous experience at Google." },
-    { name: "Marcus Rodriguez", role: "Engineering Lead", type: "Decider", priority: "Must", stance: "Neutral", influence: "High", interest: "Medium", bg: "Technical leader for the search team. Values data-driven decisions." },
-    { name: "Sarah Jenkins", role: "Design Team Lead", type: "Champion", priority: "Must", stance: "Supportive", influence: "Medium", interest: "High", bg: "Leading the design team. Strong believer in research-driven design." },
-    { name: "David Park", role: "CEO", type: "Inform", priority: "Should", stance: "Supportive", influence: "High", interest: "Low", bg: "Founder. Deeply technical. Interested in how research shapes product direction." },
-    { name: "Elena Vasquez", role: "Customer Success Lead", type: "Inform", priority: "Should", stance: "Supportive", influence: "Medium", interest: "Medium", bg: "Connects research to customer outcomes. Valuable source of user feedback." },
-    { name: "James Okafor", role: "Senior PM", type: "Decider", priority: "Must", stance: "Neutral", influence: "High", interest: "High", bg: "Owns the search product roadmap. Key partner for research prioritization." },
-    { name: "Priya Sharma", role: "Data Scientist", type: "Inform", priority: "Could", stance: "Supportive", influence: "Medium", interest: "Medium", bg: "Analytics expert. Can help quantify research impact." },
-  ];
-
-  for (const s of stakeholderData) {
-    await ctx.db.insert("stakeholders", {
-      userId,
-      name: s.name,
-      role: s.role,
-      relationshipType: s.type,
-      priority: s.priority,
-      stance: s.stance,
-      influenceLevel: s.influence,
-      interestLevel: s.interest,
-      backgroundContext: s.bg,
-      firstMeetingScheduled: false,
-      workingPreferences: [],
-    });
-  }
-
+  // ── Goals ─────────────────────────────────────────────────────────────
   const goalData = [
-    { title: "Complete stakeholder mapping and build relationships with 5+ key people", phase: 1, cat: "relationships" },
-    { title: "Deliver first actionable research insight that influences a product decision", phase: 2, cat: "shipping" },
-    { title: "Establish a repeatable research process used by the team", phase: 2, cat: "shipping" },
-    { title: "Present research-backed roadmap recommendations to leadership", phase: 3, cat: "influence" },
-    { title: "Build a research repository accessible to all teams", phase: 3, cat: "shipping" },
+    { title: "Complete Agent Studio UX Audit", phase: 1, cat: "learning" },
+    { title: "Align with Kim on agent consistency framework", phase: 1, cat: "relationships" },
+    { title: "Build trusted relationships across all three engineering teams", phase: 1, cat: "relationships" },
+    { title: "Ship first design improvement to beta customers", phase: 2, cat: "shipping" },
+    { title: "Run AI prototyping session for design team", phase: 2, cat: "influence" },
+    { title: "Establish stakeholder communication rhythm for Agent Studio design", phase: 2, cat: "influence" },
+    { title: "Contribute to shared definition of AI success for design team", phase: 2, cat: "influence" },
+    { title: "Propose strategic initiative (dashboard vision or agent UX patterns)", phase: 3, cat: "influence" },
   ];
 
   for (const g of goalData) {
@@ -276,18 +327,18 @@ async function _seedPlanData(ctx, userId) {
       status: "queued",
       trigger: "onboarding",
       inputSnapshot: {
-        companyName: "Algolia",
-        roleTitle: "Staff Product Designer",
-        industry: "Technology / SaaS",
-        companySize: "500-1000",
-        companyStage: "Growth",
-        starsSituation: "Turnaround",
-        scope: "Leading product design for Agent Studio, defining design direction and interaction patterns for AI agent interfaces",
-        experienceYears: 8,
-        teamSize: 12,
-        isNewTeam: true,
-        workModel: "Hybrid",
-        reportsTo: "Imogen Chen, VP of Product",
+        companyName: onboarding.companyName,
+        roleTitle: onboarding.roleTitle,
+        industry: onboarding.industry,
+        companySize: onboarding.companySize,
+        companyStage: onboarding.companyStage,
+        starsSituation: onboarding.starsSituation,
+        scope: onboarding.scope,
+        jobDescription: onboarding.jobDescription,
+        experienceYears: onboarding.experienceYears,
+        isNewTeam: onboarding.isNewTeam,
+        workModel: onboarding.workModel,
+        reportsTo: onboarding.reportsTo,
       },
     });
     await ctx.scheduler.runAfter(


### PR DESCRIPTION
## Summary

Refreshes the pilot user's seed data in `convex/seed.js` with the new Algolia interview seed. The pilot persona is now a sole Staff Product Designer for Agent Studio (14 yrs IC, Remote, AcceleratedGrowth, reports to Jess Shutt interim) with the full northStar / context / challenges / JD captured in onboarding.

- Phases renamed to **LEARN / SHIP / LEAD** with new milestone copy
- 12 weeks: new themes (People & Product → Reflect & Plan) and reflection prompts
- 58 activities mapped to specific days (1–60), each linked to the right stakeholder via `relatedStakeholderId`
- 12 stakeholders (Jess, Imogen, Peter, Yousef, Duncan, Kim, Etienne, Zen, Robin, Tanya, Chloe, new design leader) with rich notes in `backgroundContext`, plus `firstMeetingDate` / `cadenceDays` where the seed specified
- 8 goals
- `companyResearchJobs.inputSnapshot` rebuilt from the new onboarding

## Why these normalizations

The new JSON uses different conventions than the existing UI expects, so the seed maps them at insert time rather than churning the UI:

- **Activity priority**: `Must`/`Should` → `High`/`Medium` (today + tasks pages filter on `High`, badge styles expect `High`/`Medium`/`Low`)
- **Activity + goal category**: lowercased (UI filters use `learning`/`shipping`/`relationships`/`influence`)
- **Stakeholder priority**: `Nice` → `Could` (stakeholder page `priorityOrder` is `{Must, Should, Could}`)
- **`relatedStakeholder` string keys** → Convex Ids via an insert-time map so activities link to the right person

`relationshipType` values like `Manager`/`Peer`/`CrossFunctional`/`SkipLevel` are kept as-is — the UI badge map falls back gracefully (`typeBadge[type] || typeBadge.Inform`).

## How to apply

1. `npx convex dev` (already running) auto-pushes `seed.js` to dev. For prod: `npx convex deploy`.
2. Sign in as the pilot user (`iseghohi.john@gmail.com`) and click the existing **Reset** button on the dashboard — it calls `api.seed.resetAndReseed`, which wipes and re-seeds.
3. The `companyResearchJobs` row is intentionally left in place if it already exists (avoids re-burning tokens). Delete that row first if you want fresh research drafts on the new persona.

## Test plan

- [ ] `npx convex dev --once` succeeds (verified: `Convex functions ready`, no schema errors)
- [ ] Sign in as pilot user, click Reset on dashboard, confirm new persona appears in onboarding view
- [ ] Phases page shows LEARN / SHIP / LEAD
- [ ] Today / tasks pages render activities with `High`/`Medium` priorities and lowercase categories
- [ ] Stakeholder list shows 12 entries; detail view renders the `backgroundContext` notes
- [ ] Activities with `rel: "jess"` etc. show the correct related stakeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced onboarding template with improved role, team, and company details
  * Restructured planning phases with a new workflow: Agent Studio UX audit → quick win → strategic initiative
  * Updated week reflection prompts for improved guidance
  * Expanded stakeholder dataset for better planning context
  * Enhanced activity prioritization system
  * Revised goals aligned with updated planning narrative

<!-- end of auto-generated comment: release notes by coderabbit.ai -->