### PR TITLE
fix(a11y+copy): autoComplete attrs + honest plan-gen copy

### DIFF
--- a/src/app/(app)/dashboard/page.js
+++ b/src/app/(app)/dashboard/page.js
@@ -102,7 +102,7 @@ export default function DashboardPage() {
             Building your plan&hellip;
           </h2>
           <p className="font-space-grotesk text-sm text-[#A8A29E] max-w-md mx-auto">
-            We&apos;re generating your personalised 90-day plan. This usually takes 30&ndash;60 seconds.
+            We&apos;re generating your personalised 90-day plan. This usually takes about a minute. Feel free to grab a coffee — the page will update automatically.
             You can wait here &mdash; the page will update automatically.
           </p>
           <div className="w-48 mx-auto h-1.5 bg-[#292524] rounded-full overflow-hidden">

--- a/src/app/(auth)/forgot-password/page.js
+++ b/src/app/(auth)/forgot-password/page.js
@@ -66,6 +66,8 @@ export default function ForgotPasswordPage() {
             id="email"
             type="email"
             required
+            autoComplete="email"
+            inputMode="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className="w-full bg-white border border-[#E7E5E4] rounded-lg px-3 py-2.5 font-space-grotesk text-sm text-[#1C1917] placeholder:text-[#D1CDC7] focus:outline-none focus:ring-2 focus:ring-[#D97757]/20 focus:border-[#D97757] transition"

--- a/src/app/(auth)/login/page.js
+++ b/src/app/(auth)/login/page.js
@@ -132,6 +132,8 @@ function LoginInner() {
             id="email"
             type="email"
             required
+            autoComplete="email"
+            inputMode="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className="w-full bg-white border border-[#E7E5E4] rounded-lg px-3 py-2.5 font-space-grotesk text-sm text-[#1C1917] placeholder:text-[#D1CDC7] focus:outline-none focus:ring-2 focus:ring-[#D97757]/20 focus:border-[#D97757] transition"
@@ -158,6 +160,7 @@ function LoginInner() {
             id="password"
             type="password"
             required
+            autoComplete="current-password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             className="w-full bg-white border border-[#E7E5E4] rounded-lg px-3 py-2.5 font-space-grotesk text-sm text-[#1C1917] placeholder:text-[#D1CDC7] focus:outline-none focus:ring-2 focus:ring-[#D97757]/20 focus:border-[#D97757] transition"

--- a/src/app/(auth)/reset-password/page.js
+++ b/src/app/(auth)/reset-password/page.js
@@ -100,6 +100,8 @@ function ResetPasswordInner() {
             id="email"
             type="email"
             required
+            autoComplete="email"
+            inputMode="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className="w-full bg-white border border-[#E7E5E4] rounded-lg px-3 py-2.5 font-space-grotesk text-sm text-[#1C1917] placeholder:text-[#D1CDC7] focus:outline-none focus:ring-2 focus:ring-[#D97757]/20 focus:border-[#D97757] transition"
@@ -139,6 +141,7 @@ function ResetPasswordInner() {
             id="password"
             type="password"
             required
+            autoComplete="new-password"
             minLength={PASSWORD_MIN_LENGTH}
             value={password}
             onChange={(e) => setPassword(e.target.value)}

--- a/src/app/(auth)/signup/page.js
+++ b/src/app/(auth)/signup/page.js
@@ -139,6 +139,8 @@ export default function SignupPage() {
             id="email"
             type="email"
             required
+            autoComplete="email"
+            inputMode="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className="w-full bg-white border border-[#E7E5E4] rounded-lg px-3 py-2.5 font-space-grotesk text-sm text-[#1C1917] placeholder:text-[#D1CDC7] focus:outline-none focus:ring-2 focus:ring-[#D97757]/20 focus:border-[#D97757] transition"
@@ -157,6 +159,7 @@ export default function SignupPage() {
             id="password"
             type="password"
             required
+            autoComplete="new-password"
             minLength={PASSWORD_MIN_LENGTH}
             value={password}
             onChange={(e) => setPassword(e.target.value)}

--- a/src/app/(auth)/verify-email/page.js
+++ b/src/app/(auth)/verify-email/page.js
@@ -132,6 +132,8 @@ function VerifyEmailInner() {
               id="email"
               type="email"
               required
+              autoComplete="email"
+              inputMode="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               className="w-full bg-white border border-[#E7E5E4] rounded-lg px-3 py-2.5 font-space-grotesk text-sm text-[#1C1917] placeholder:text-[#D1CDC7] focus:outline-none focus:ring-2 focus:ring-[#D97757]/20 focus:border-[#D97757] transition"

--- a/src/components/plan/RegeneratePlanModal.js
+++ b/src/components/plan/RegeneratePlanModal.js
@@ -93,7 +93,7 @@ export default function RegeneratePlanModal({ onClose }) {
         {busy && (
           <div className="flex items-center gap-3 text-sm text-[#A8A29E] font-space-grotesk">
             <div className="w-4 h-4 border-2 border-[#D97757] border-t-transparent rounded-full animate-spin" />
-            <span>Drafting your new plan… this takes 30-60 seconds.</span>
+            <span>Drafting your new plan… this usually takes about a minute.</span>
           </div>
         )}
 


### PR DESCRIPTION
## What

Two safe, low-risk polish fixes pulled out of the launch-blockers audit so they can ship in parallel with the pilot-test-user reseed branch without merge conflicts. No data-layer or onboarding flow changes.

## Auth forms — autoComplete attributes

Adds missing autoComplete and inputMode where relevant so password managers and mobile keyboards behave correctly:

- signup: email -> email + inputMode; password -> new-password
- login: email -> email + inputMode; password -> current-password
- forgot-password: email -> email + inputMode
- reset-password: email -> email + inputMode; password -> new-password
- verify-email (re-send variant): email -> email + inputMode

Eliminates the 'Input elements should have autocomplete attributes' console warning observed during live testing.

## Plan-generation copy — honest expectations

Live test showed plan generation takes ~90s, but the UI promised '30-60 seconds'. Updated to:

> 'This usually takes about a minute. Feel free to grab a coffee — the page will update automatically.'

Affects dashboard Building-your-plan card and RegeneratePlanModal.

## Out of scope

Bigger onboarding bugs found in the same audit (stakeholder/scope persistence in saveOnboardingProgress, Step 6 summary showing — for goals/stakeholders, Continue click reliability) are intentionally NOT in this PR. They overlap with the in-flight pilot-test-user reseed branch and will be revisited once that lands. Tracked as separate GitHub issues.

## Verification

- pnpm lint clean (0 errors, 0 warnings)
- No state, schema, or routing changes
- Each change is a single-attribute or copy diff

🦀