### PR TITLE
fix(onboarding): P0 launch blockers — persist stakeholders + scope, fix state leak

### DIFF
--- a/convex/users.js
+++ b/convex/users.js
@@ -263,6 +263,23 @@ export const saveOnboardingProgress = mutation({
       existingContext: v.optional(v.string()),
       challenges: v.optional(v.string()),
       jobDescription: v.optional(v.string()),
+      // Free-text role scope (Step 2). Persisted across steps so users
+      // don't lose what they typed if a Convex query re-fires and the
+      // viewer-restore effect re-hydrates local state.
+      scope: v.optional(v.string()),
+      // Stakeholders entered on Step 5. They are only flushed to the
+      // dedicated stakeholders table on the final handleSubmit (Step 6),
+      // so we mirror them here every step to survive client-side
+      // state-resyncs.
+      stakeholders: v.optional(
+        v.array(
+          v.object({
+            name: v.string(),
+            title: v.string(),
+            relationship: v.string(),
+          })
+        )
+      ),
     }),
   },
   handler: async (ctx, args) => {

--- a/src/app/onboarding/[step]/page.js
+++ b/src/app/onboarding/[step]/page.js
@@ -278,10 +278,40 @@ export default function OnboardingStepPage({ params }) {
   }
 
   async function handleNext() {
-    const { stakeholders, scope, ...saveable } = data;
+    // Step 5 (currentStep === 4) lets users add stakeholder rows. If they
+    // typed into a row but never clicked "Add another", the row is still
+    // in `data.stakeholders` (pre-seeded with one empty entry) but won't
+    // be picked up by handleSubmit's `validStakeholders` filter unless we
+    // keep it. Filter to drop fully-empty rows but preserve any with at
+    // least a name OR title typed — they'll show up on Step 6 summary and
+    // get flushed to the stakeholders table on submit.
+    const cleanedStakeholders = (data.stakeholders || []).filter(
+      (s) =>
+        (s.name ?? "").trim() !== "" || (s.title ?? "").trim() !== ""
+    );
+
+    // Persist EVERYTHING on every step — including stakeholders and scope
+    // — so a Convex query re-fire / viewer-restore effect can't blank
+    // them. The schema in convex/users.js was updated to match.
+    const saveable = {
+      ...data,
+      stakeholders: cleanedStakeholders,
+    };
+
     if (currentStep < TOTAL_STEPS - 1) {
       // Fire-and-forget for intermediate steps — don't block navigation
       saveOnboardingProgress({ step: currentStep, data: saveable }).catch(() => {});
+      // Mirror the cleaned stakeholders back into local state so the
+      // Step 6 summary doesn't render the stale empty row.
+      if (cleanedStakeholders.length !== (data.stakeholders || []).length) {
+        setData((prev) => ({
+          ...prev,
+          stakeholders:
+            cleanedStakeholders.length > 0
+              ? cleanedStakeholders
+              : [{ ...EMPTY_STAKEHOLDER }],
+        }));
+      }
       router.push(`/onboarding/${currentStep + 2}`);
     } else {
       // On the final step, await the save so it completes before
@@ -518,8 +548,13 @@ export default function OnboardingStepPage({ params }) {
                 </div>
 
                 <div>
-                  <label className={labelClass}>Describe your role scope (optional)</label>
+                  <label className={labelClass} htmlFor="onboarding-scope">
+                    Describe your role scope (optional)
+                  </label>
                   <input
+                    id="onboarding-scope"
+                    name="onboarding-scope"
+                    autoComplete="off"
                     value={data.scope ?? ""}
                     onChange={(e) => update("scope", e.target.value)}
                     className={inputClass}
@@ -692,9 +727,17 @@ export default function OnboardingStepPage({ params }) {
 
               <div className="space-y-5 mt-6 onboarding-fade-in-d4">
                 <div>
-                  <label className={labelClass}>What does success look like at 90 days?</label>
+                  <label
+                    className={labelClass}
+                    htmlFor="onboarding-success-definition"
+                  >
+                    What does success look like at 90 days?
+                  </label>
                   <p className="text-xs text-warm-300 mb-2 font-space-grotesk">Your personal definition -- not just what the company expects.</p>
                   <textarea
+                    id="onboarding-success-definition"
+                    name="onboarding-success-definition"
+                    autoComplete="off"
                     rows={3}
                     value={data.successDefinition}
                     onChange={(e) => update("successDefinition", e.target.value)}
@@ -753,11 +796,19 @@ export default function OnboardingStepPage({ params }) {
 
               <div className="space-y-5 mt-6">
                 <div>
-                  <label className={labelClass}>Paste your job description (optional)</label>
+                  <label
+                    className={labelClass}
+                    htmlFor="onboarding-job-description"
+                  >
+                    Paste your job description (optional)
+                  </label>
                   <p className="text-xs text-warm-300 mb-2 font-space-grotesk">
                     If you have it, paste the full JD here. We&apos;ll use it to research your company and pre-build context into your knowledge base.
                   </p>
                   <textarea
+                    id="onboarding-job-description"
+                    name="onboarding-job-description"
+                    autoComplete="off"
                     rows={5}
                     value={data.jobDescription}
                     onChange={(e) => update("jobDescription", e.target.value)}
@@ -766,9 +817,17 @@ export default function OnboardingStepPage({ params }) {
                   />
                 </div>
                 <div>
-                  <label className={labelClass}>What do you already know about the team or company? (optional)</label>
+                  <label
+                    className={labelClass}
+                    htmlFor="onboarding-existing-context"
+                  >
+                    What do you already know about the team or company? (optional)
+                  </label>
                   <p className="text-xs text-warm-300 mb-2 font-space-grotesk">Any intel from interviews, conversations, or research.</p>
                   <textarea
+                    id="onboarding-existing-context"
+                    name="onboarding-existing-context"
+                    autoComplete="off"
                     rows={3}
                     value={data.existingContext}
                     onChange={(e) => update("existingContext", e.target.value)}
@@ -777,9 +836,17 @@ export default function OnboardingStepPage({ params }) {
                   />
                 </div>
                 <div>
-                  <label className={labelClass}>Any specific challenges or risks you&apos;re aware of? (optional)</label>
+                  <label
+                    className={labelClass}
+                    htmlFor="onboarding-challenges"
+                  >
+                    Any specific challenges or risks you&apos;re aware of? (optional)
+                  </label>
                   <p className="text-xs text-warm-300 mb-2 font-space-grotesk">Things you want to watch out for or navigate carefully.</p>
                   <textarea
+                    id="onboarding-challenges"
+                    name="onboarding-challenges"
+                    autoComplete="off"
                     rows={3}
                     value={data.challenges}
                     onChange={(e) => update("challenges", e.target.value)}


### PR DESCRIPTION
## Why

Three P0 bugs found during the live launch test on 2026-04-25 (production, https://first90days.vercel.app). Each one independently breaks user trust at signup. All three are now fixed with no schema migration needed (additive optional fields).

Closes #29, #30, #31. Partially addresses #32.

## Bugs fixed

### #29 — stakeholders + scope silently dropped (P0)

`handleNext()` was destructuring `stakeholders` and `scope` OUT of the payload sent to `saveOnboardingProgress`. The Convex validator didn't accept them either, so they were never persisted to `partialOnboarding` between steps. They only landed in the DB on the final `handleSubmit` (Step 6) — any client-side state-resync (viewer-restore effect, focus event) could blank them.

### #30 — Step 6 summary shows '—' for goals + stakeholders (P0)

Same root cause as #29. With stakeholders + scope now persisted every step, the summary card renders the right values.

### #31 — Step 5 textarea pre-fills with previous step's text (P0)

Onboarding textareas had no unique id/name/autoComplete. Browser autofill could grab any similarly-shaped earlier field. Added unique htmlFor / id / name + autoComplete='off' to all 5 free-text fields:
- Step 2 scope input
- Step 4 successDefinition textarea
- Step 5 jobDescription textarea
- Step 5 existingContext textarea
- Step 5 challenges textarea

### #32 (partial) — stakeholder discarded if user clicks Continue without 'Add'

handleNext now flushes in-progress rows that have at least a name OR title typed, so users who only fill the inline form (most users) don't lose their entry.

## Files changed

| File | Why |
|---|---|
| convex/users.js | Add optional stakeholders + scope to saveOnboardingProgress validator |
| src/app/onboarding/[step]/page.js | Stop destructuring; auto-flush rows; add unique ids on textareas |

## Verification

- pnpm lint clean (0 errors, 0 warnings)
- No conflict with PR #27 (seed-data only)
- Schema is additive (optional fields) — existing partialOnboarding rows remain valid
- Will live-test the full signup → onboarding → plan generation flow on a fresh account once this lands in preview

🦀