### PR TITLE
fix(dashboard): remove duplicate 'page will update' line

### DIFF
--- a/src/app/(app)/dashboard/page.js
+++ b/src/app/(app)/dashboard/page.js
@@ -103,7 +103,6 @@ export default function DashboardPage() {
           </h2>
           <p className="font-space-grotesk text-sm text-[#A8A29E] max-w-md mx-auto">
             We&apos;re generating your personalised 90-day plan. This usually takes about a minute. Feel free to grab a coffee — the page will update automatically.
-            You can wait here &mdash; the page will update automatically.
           </p>
           <div className="w-48 mx-auto h-1.5 bg-[#292524] rounded-full overflow-hidden">
             <div className="h-full bg-[#D97757] rounded-full animate-pulse w-3/4" />


### PR DESCRIPTION
Tiny follow-up to PR #28. The original 'You can wait here — the page will update automatically.' tail wasn't deleted, so the loading card now says the same thing twice. Removed.

🦀