### PR TITLE
fix(csp): allow Convex storage URLs in img-src so avatars render

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,7 @@ const CSP = [
   "script-src 'self' 'unsafe-inline' js.stripe.com",
   "style-src 'self' 'unsafe-inline'",
   "connect-src 'self' https://*.convex.cloud wss://*.convex.cloud https://hooks.stripe.com",
-  "img-src 'self' data: blob:",
+  "img-src 'self' data: blob: https://*.convex.cloud",
   "font-src 'self'",
   "object-src 'none'",
   "base-uri 'self'",


### PR DESCRIPTION
## Summary
- Profile avatars uploaded from Settings appeared as broken images and looked like the upload had failed.
- Root cause: CSP `img-src 'self' data: blob:` (added in f10f8b9) blocked the signed `https://*.convex.cloud` URLs returned by `ctx.storage.getUrl()` and rendered via `<img>` in [src/app/(app)/settings/page.js:803](src/app/(app)/settings/page.js).
- The upload + save mutation were actually working — `connect-src` already allows `convex.cloud` over HTTPS and WSS — only the render was blocked.
- Fix: add `https://*.convex.cloud` to `img-src`.

## Test plan
- [ ] Hard-refresh `/settings` (Cmd+Shift+R) so the new CSP is applied to the document
- [ ] Click "Change avatar" → pick a JPG/PNG/GIF/WebP under 1MB
- [ ] Image renders inline in the avatar slot (no broken-image icon)
- [ ] Reload the page → avatar persists
- [ ] Click "Remove" → falls back to initials
- [ ] Confirm in DevTools Network tab that the image request to `*.convex.cloud` returns 200 (no `Refused to load the image` console error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)