### PR TITLE
fix(progress): phase bars fill proportionally to day, not hardcoded full

### DIFF
--- a/src/app/(app)/dashboard/page.js
+++ b/src/app/(app)/dashboard/page.js
@@ -328,26 +328,49 @@ export default function DashboardPage() {
             </div>
             <div className="flex items-center gap-2 mb-3">
               {[
-                { name: "Learn", days: "Days 1-30", active: dayInfo.phase >= 1 },
-                { name: "Contribute", days: "Days 31-60", active: dayInfo.phase >= 2 },
-                { name: "Lead", days: "Days 61-90", active: dayInfo.phase >= 3 },
-              ].map((phase) => (
-                <div key={phase.name} className="flex-1">
-                  <div
-                    className={`h-1 rounded-full ${
-                      phase.active ? "bg-[#D97757]" : "bg-[#292524]"
-                    }`}
-                  />
-                  <div className="mt-2 flex items-center justify-between">
-                    <span className="font-space-grotesk text-xs font-medium text-[#E7E5E4]">
-                      {phase.name}
-                    </span>
-                    <span className="font-space-grotesk text-xs text-[#A8A29E]">
-                      {phase.days}
-                    </span>
+                { name: "Learn", days: "Days 1-30", number: 1, dayStart: 1, dayEnd: 30 },
+                { name: "Contribute", days: "Days 31-60", number: 2, dayStart: 31, dayEnd: 60 },
+                { name: "Lead", days: "Days 61-90", number: 3, dayStart: 61, dayEnd: 90 },
+              ].map((phase) => {
+                // Fraction (0–1) of how far into THIS phase the user has
+                // travelled. Past phases are 1, future phases are 0.
+                let fillFraction = 0;
+                if (dayInfo.dayNumber >= phase.dayEnd) {
+                  fillFraction = 1;
+                } else if (dayInfo.dayNumber >= phase.dayStart) {
+                  const span = phase.dayEnd - phase.dayStart + 1; // inclusive
+                  const done = dayInfo.dayNumber - phase.dayStart + 1;
+                  fillFraction = Math.max(0, Math.min(1, done / span));
+                }
+                const isCurrent = dayInfo.phase === phase.number;
+                return (
+                  <div key={phase.name} className="flex-1">
+                    <div className="h-1 rounded-full bg-[#292524] overflow-hidden relative">
+                      <div
+                        className="h-full bg-[#D97757] rounded-full transition-[width] duration-300 ease-out"
+                        style={{ width: `${fillFraction * 100}%` }}
+                      />
+                    </div>
+                    <div className="mt-2 flex items-center justify-between">
+                      <span
+                        className={`font-space-grotesk text-xs font-medium ${
+                          isCurrent ? "text-[#D97757]" : "text-[#E7E5E4]"
+                        }`}
+                      >
+                        {phase.name}
+                        {isCurrent ? (
+                          <span className="ml-1.5 text-[10px] uppercase tracking-wider text-[#D97757]/80">
+                            Now
+                          </span>
+                        ) : null}
+                      </span>
+                      <span className="font-space-grotesk text-xs text-[#A8A29E]">
+                        {phase.days}
+                      </span>
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
 

--- a/src/app/(app)/plan/page.js
+++ b/src/app/(app)/plan/page.js
@@ -314,27 +314,51 @@ export default function PlanPage() {
         </div>
       )}
 
-      {/* Phase progress */}
+      {/* Phase progress — proportional fill within each phase based on dayNumber */}
       <div className="flex items-center gap-2">
-        {fullPlan.phases.map((phase) => (
-          <div key={phase._id} className="flex-1">
-            <div
-              className={`h-1 rounded-full ${
-                dayInfo && dayInfo.phase >= phase.number
-                  ? "bg-[#D97757]"
-                  : "bg-[#292524]"
-              }`}
-            />
-            <div className="mt-2 flex items-center justify-between">
-              <span className="font-space-grotesk text-xs font-medium text-[#E7E5E4]">
-                {phaseLabels[phase.number]?.name}
-              </span>
-              <span className="font-space-grotesk text-xs text-[#A8A29E]">
-                {phaseLabels[phase.number]?.days}
-              </span>
+        {fullPlan.phases.map((phase) => {
+          // Each phase covers 30 days. Phase 1 = days 1–30, etc.
+          const dayStart = (phase.number - 1) * 30 + 1;
+          const dayEnd = phase.number * 30;
+          let fillFraction = 0;
+          if (dayInfo) {
+            if (dayInfo.dayNumber >= dayEnd) {
+              fillFraction = 1;
+            } else if (dayInfo.dayNumber >= dayStart) {
+              const span = dayEnd - dayStart + 1;
+              const done = dayInfo.dayNumber - dayStart + 1;
+              fillFraction = Math.max(0, Math.min(1, done / span));
+            }
+          }
+          const isCurrent = dayInfo && dayInfo.phase === phase.number;
+          return (
+            <div key={phase._id} className="flex-1">
+              <div className="h-1 rounded-full bg-[#292524] overflow-hidden">
+                <div
+                  className="h-full bg-[#D97757] rounded-full transition-[width] duration-300 ease-out"
+                  style={{ width: `${fillFraction * 100}%` }}
+                />
+              </div>
+              <div className="mt-2 flex items-center justify-between">
+                <span
+                  className={`font-space-grotesk text-xs font-medium ${
+                    isCurrent ? "text-[#D97757]" : "text-[#E7E5E4]"
+                  }`}
+                >
+                  {phaseLabels[phase.number]?.name}
+                  {isCurrent ? (
+                    <span className="ml-1.5 text-[10px] uppercase tracking-wider text-[#D97757]/80">
+                      Now
+                    </span>
+                  ) : null}
+                </span>
+                <span className="font-space-grotesk text-xs text-[#A8A29E]">
+                  {phaseLabels[phase.number]?.days}
+                </span>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Weeks by phase */}


### PR DESCRIPTION
## Bug

Caught during live testing on 2026-04-25: on **Day 1** the dashboard 'Onboarding Journey' progress bar showed **Days 1-30 fully filled in orange**, suggesting the user had already completed the entire Learn phase. They've barely started.

## Root cause

The phase bar used a binary active flag tied to `dayInfo.phase >= phase.number`. Since Phase 1 starts on Day 1, the flag is true from Day 1, which fills the bar 100%. There's no concept of progress *within* a phase.

`/plan` had the same pattern.

## Fix

Replace the binary fill with a **proportional fill based on dayNumber**:

- Past phases → 100% (orange)
- Future phases → 0% (dark)
- Current phase → fills 1/30, 2/30, ... 30/30 as days pass

Plus the current phase label gets orange colour + a small 'Now' badge. So Day 1 reads as 'I'm at the start of Learn' instead of 'I'm done with Learn.'

## Files changed

- src/app/(app)/dashboard/page.js — Onboarding Journey card
- src/app/(app)/plan/page.js — same pattern on Strategic Plan page

The shared/[planId] page uses the same binary pattern but in a 'this section applies once you reach phase X' context where binary is accurate. Left alone.

## Verification

- pnpm lint clean
- No behavioural changes beyond the visual; dayInfo shape unchanged

🦀