### PR TITLE
fix(progress): pre-boarding bar fills with checklist progress

### DIFF
--- a/src/app/(app)/dashboard/page.js
+++ b/src/app/(app)/dashboard/page.js
@@ -189,27 +189,47 @@ export default function DashboardPage() {
             </p>
           </div>
 
-          {/* Phase bar — all grayed out */}
+          {/* Phase bar — Pre-boarding fills proportionally to checklist progress;
+              future phases stay empty until the plan starts. */}
           <div className="bg-[#1C1917] border border-[#2C2825] rounded-xl p-4 sm:p-6">
             <h3 className="font-space-grotesk text-sm font-medium text-[#A8A29E] mb-4">
               Onboarding Journey
             </h3>
             <div className="flex items-center gap-2 mb-3">
               {[
-                { name: "Pre-boarding", days: `T-${dayInfo.daysUntilStart}`, active: true },
-                { name: "Learn", days: "Days 1-30", active: false },
-                { name: "Contribute", days: "Days 31-60", active: false },
-                { name: "Lead", days: "Days 61-90", active: false },
+                {
+                  name: "Pre-boarding",
+                  days: `T-${dayInfo.daysUntilStart}`,
+                  fillFraction:
+                    PRE_BOARDING_CHECKLIST.length > 0
+                      ? Object.values(checked).filter(Boolean).length /
+                        PRE_BOARDING_CHECKLIST.length
+                      : 0,
+                  isCurrent: true,
+                },
+                { name: "Learn", days: "Days 1-30", fillFraction: 0, isCurrent: false },
+                { name: "Contribute", days: "Days 31-60", fillFraction: 0, isCurrent: false },
+                { name: "Lead", days: "Days 61-90", fillFraction: 0, isCurrent: false },
               ].map((phase) => (
                 <div key={phase.name} className="flex-1">
-                  <div
-                    className={`h-1 rounded-full ${
-                      phase.active ? "bg-[#D97757]" : "bg-[#292524]"
-                    }`}
-                  />
+                  <div className="h-1 rounded-full bg-[#292524] overflow-hidden">
+                    <div
+                      className="h-full bg-[#D97757] rounded-full transition-[width] duration-300 ease-out"
+                      style={{ width: `${phase.fillFraction * 100}%` }}
+                    />
+                  </div>
                   <div className="mt-2 flex items-center justify-between">
-                    <span className="font-space-grotesk text-xs font-medium text-[#E7E5E4]">
+                    <span
+                      className={`font-space-grotesk text-xs font-medium ${
+                        phase.isCurrent ? "text-[#D97757]" : "text-[#E7E5E4]"
+                      }`}
+                    >
                       {phase.name}
+                      {phase.isCurrent ? (
+                        <span className="ml-1.5 text-[10px] uppercase tracking-wider text-[#D97757]/80">
+                          Now
+                        </span>
+                      ) : null}
                     </span>
                     <span className="font-space-grotesk text-xs text-[#A8A29E]">
                       {phase.days}


### PR DESCRIPTION
## Bug

Same class of issue as #39, but in the **pre-boarding** variant of the dashboard's *Onboarding Journey* card. Caught on the pilot seed account (John Iseghohi, `iseghohi.john@gmail.com`, plan start `2026-05-11`).

When the pilot user lands on the dashboard ahead of Day 1 (today is `2026-04-25`, T-16), the Pre-boarding segment of the phase bar is rendered fully orange — making it look like the user has already completed pre-boarding, even when **0/7 of the pre-boarding checklist items are ticked**.

## Root cause

The pre-boarding phase bar in `src/app/(app)/dashboard/page.js` hardcoded the current segment to `active: true`:

```js
{ name: "Pre-boarding", days: `T-${dayInfo.daysUntilStart}`, active: true },
{ name: "Learn", days: "Days 1-30", active: false },
…
```

…and then drove the bar fill from that binary flag. There was no concept of *progress within* pre-boarding, so the bar was 100% on Day -16 the same way it would be on Day -1.

PR #39 fixed exactly this pattern for the active-plan phase bars on `/dashboard` and `/plan` (`dayInfo.phase >= phase.number` → `fillFraction = daysCompletedInPhase / 30`). The pre-boarding variant was overlooked.

## Fix

Mirror the #39 pattern in the pre-boarding bar:

- **Pre-boarding** fills proportionally: `width = (checked / PRE_BOARDING_CHECKLIST.length)`. 0/7 → 0%, 7/7 → 100%. Drives off the same `useChecklistState()` value the checklist below already renders.
- **Learn / Contribute / Lead** stay at 0% (user hasn't started — was already visually correct as gray; kept the same structure as #39 so all rows go through one render path).
- Pre-boarding label gets the orange colour + small `Now` badge, matching the current-phase styling introduced in #39.

## Files changed

- `src/app/(app)/dashboard/page.js` — pre-boarding-state phase bar only. The active-plan phase bar lower in the file already has the #39 fix.

## Verification

- `pnpm lint` clean.
- Sign in as the pilot seed user, land on `/dashboard` pre-Day 1: Pre-boarding bar should read **0% with 0 items checked**, and grow in 1/7 increments as you tick checklist items. Future phases remain empty until the plan begins.
- Live preview verification was blocked by a disconnected preview client this session; the change is structurally identical to the validated #39 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced onboarding journey progress bar to display proportional progress based on completed pre-boarding tasks, providing visual clarity on your current phase and completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->