### PR TITLE
feat(email): brand-consistent HTML for all auth + lifecycle templates

### DIFF
--- a/convex/ResendOTP.js
+++ b/convex/ResendOTP.js
@@ -1,5 +1,6 @@
 import Resend from "@auth/core/providers/resend";
 import { Resend as ResendAPI } from "resend";
+import { renderEmailShell, renderCodeBlock, BRAND } from "./lib/emailLayout";
 
 // Email verification provider for @convex-dev/auth's Password provider.
 // Emits an 8-digit numeric code (20-minute expiry, set by convex-auth).
@@ -7,7 +8,10 @@ import { Resend as ResendAPI } from "resend";
 // the code is logged so local dev without a Resend account can still
 // complete the flow by copying the code from the server log.
 
-const FROM_ADDRESS = process.env.AUTH_EMAIL ?? "First90 <onboarding@resend.dev>";
+const FROM_ADDRESS = process.env.AUTH_EMAIL ?? "First90 <hello@switchtoux.com>";
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.first90days.com";
+const PRODUCT_NAME = process.env.PRODUCT_NAME ?? "First90";
+const LOGO_URL = process.env.EMAIL_LOGO_URL ?? "";
 
 function generateNumericCode(length = 8) {
   const digits = new Uint32Array(length);
@@ -17,6 +21,23 @@ function generateNumericCode(length = 8) {
     out += (digits[i] % 10).toString();
   }
   return out;
+}
+
+function buildVerificationHtml(code) {
+  const inner = `
+<h1 style="margin:0 0 8px;font-family:${BRAND.font};font-size:22px;line-height:1.3;font-weight:700;color:${BRAND.ink};">Confirm your email</h1>
+<p style="margin:0 0 8px;font-family:${BRAND.font};font-size:15px;line-height:1.6;color:${BRAND.inkSoft};">Enter this 8-digit code to finish signing in:</p>
+${renderCodeBlock(code)}
+<p style="margin:0 0 8px;font-family:${BRAND.font};font-size:14px;line-height:1.6;color:${BRAND.inkSoft};">This code expires in 20 minutes.</p>
+<p style="margin:0;font-family:${BRAND.font};font-size:14px;line-height:1.6;color:${BRAND.muted};">If you didn't request this, you can safely ignore this email — no account will be created.</p>`;
+  return renderEmailShell({
+    preheader: `Your ${PRODUCT_NAME} verification code`,
+    appUrl: APP_URL,
+    productName: PRODUCT_NAME,
+    logoUrl: LOGO_URL,
+    innerHtml: inner,
+    showManageNotifications: false,
+  });
 }
 
 export const ResendOTP = Resend({
@@ -40,11 +61,14 @@ export const ResendOTP = Resend({
     const { error } = await resend.emails.send({
       from: FROM_ADDRESS,
       to: [email],
-      subject: "Your First90 verification code",
+      subject: `Your ${PRODUCT_NAME} verification code`,
+      html: buildVerificationHtml(token),
       text: [
-        `Your First90 verification code is: ${token}`,
+        `Your ${PRODUCT_NAME} verification code is: ${token}`,
         "",
-        "This code expires in 20 minutes. If you didn't request it, you can ignore this email.",
+        "Enter this code to finish signing in. It expires in 20 minutes.",
+        "",
+        "If you didn't request this, you can safely ignore this email.",
       ].join("\n"),
     });
     if (error) {

--- a/convex/ResendOTPPasswordReset.js
+++ b/convex/ResendOTPPasswordReset.js
@@ -1,12 +1,16 @@
 import Resend from "@auth/core/providers/resend";
 import { Resend as ResendAPI } from "resend";
+import { renderEmailShell, renderCodeBlock, BRAND } from "./lib/emailLayout";
 
 // Password-reset OTP provider for @convex-dev/auth's Password provider.
 // Convex Auth calls this on `flow: "reset"` to deliver a one-time code
 // that the user then submits with their new password via
 // `flow: "reset-verification"`.
 
-const FROM_ADDRESS = process.env.AUTH_EMAIL ?? "First90 <onboarding@resend.dev>";
+const FROM_ADDRESS = process.env.AUTH_EMAIL ?? "First90 <hello@switchtoux.com>";
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.first90days.com";
+const PRODUCT_NAME = process.env.PRODUCT_NAME ?? "First90";
+const LOGO_URL = process.env.EMAIL_LOGO_URL ?? "";
 
 function generateNumericCode(length = 8) {
   const digits = new Uint32Array(length);
@@ -16,6 +20,23 @@ function generateNumericCode(length = 8) {
     out += (digits[i] % 10).toString();
   }
   return out;
+}
+
+function buildResetHtml(code) {
+  const inner = `
+<h1 style="margin:0 0 8px;font-family:${BRAND.font};font-size:22px;line-height:1.3;font-weight:700;color:${BRAND.ink};">Reset your password</h1>
+<p style="margin:0 0 8px;font-family:${BRAND.font};font-size:15px;line-height:1.6;color:${BRAND.inkSoft};">Use this 8-digit code in the password reset form, along with your new password:</p>
+${renderCodeBlock(code)}
+<p style="margin:0 0 8px;font-family:${BRAND.font};font-size:14px;line-height:1.6;color:${BRAND.inkSoft};">This code expires in 20 minutes.</p>
+<p style="margin:0;font-family:${BRAND.font};font-size:14px;line-height:1.6;color:${BRAND.muted};">If you didn't request a password reset, you can safely ignore this email — your current password will continue to work.</p>`;
+  return renderEmailShell({
+    preheader: `Your ${PRODUCT_NAME} password reset code`,
+    appUrl: APP_URL,
+    productName: PRODUCT_NAME,
+    logoUrl: LOGO_URL,
+    innerHtml: inner,
+    showManageNotifications: false,
+  });
 }
 
 export const ResendOTPPasswordReset = Resend({
@@ -39,11 +60,12 @@ export const ResendOTPPasswordReset = Resend({
     const { error } = await resend.emails.send({
       from: FROM_ADDRESS,
       to: [email],
-      subject: "Reset your First90 password",
+      subject: `Reset your ${PRODUCT_NAME} password`,
+      html: buildResetHtml(token),
       text: [
-        `Your First90 password reset code is: ${token}`,
+        `Your ${PRODUCT_NAME} password reset code is: ${token}`,
         "",
-        "Enter this code in the app along with your new password. The code expires in 20 minutes.",
+        "Enter this code in the password reset form along with your new password. The code expires in 20 minutes.",
         "",
         "If you didn't request a password reset, you can safely ignore this email — your current password will continue to work.",
       ].join("\n"),

--- a/convex/emailActions.js
+++ b/convex/emailActions.js
@@ -4,13 +4,27 @@ import { v } from "convex/values";
 import { internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { Resend } from "resend";
+import {
+  renderTemplate,
+  renderQuote,
+  renderNote,
+  escapeHtml,
+  BRAND,
+} from "./lib/emailLayout";
 
+// Sender + identity. AUTH_EMAIL is the canonical override for ALL outgoing
+// mail (auth + lifecycle) and is the env var Convex auth's resend providers
+// also read, so keeping a single source of truth across all email modules
+// avoids the drift we had before (auth came from one address, lifecycle
+// from another).
 const FROM_ADDRESS =
   process.env.RESEND_FROM_EMAIL ??
   process.env.AUTH_EMAIL ??
-  "First90 <hello@first90days.com>";
+  "First90 <hello@switchtoux.com>";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.first90days.com";
+const PRODUCT_NAME = process.env.PRODUCT_NAME ?? "First90";
+const LOGO_URL = process.env.EMAIL_LOGO_URL ?? "";
 
 function getResend() {
   const apiKey = process.env.AUTH_RESEND_KEY;
@@ -32,6 +46,26 @@ async function sendEmail(resend, { to, subject, html, text }) {
   if (error) throw new Error(`Resend error: ${error.message}`);
 }
 
+// Reusable building blocks scoped to lifecycle emails. Anything user-supplied
+// (names, role titles, comment bodies, etc.) MUST flow through escapeHtml
+// before being interpolated into the bodyHtml string.
+
+function renderBulletList(items) {
+  if (!items || items.length === 0) return "";
+  const lis = items
+    .map(
+      (raw) =>
+        `<li style="margin:0 0 8px;color:${BRAND.inkSoft};font-family:${BRAND.font};font-size:15px;line-height:1.5;">${escapeHtml(raw)}</li>`
+    )
+    .join("");
+  return `<ul style="margin:14px 0;padding-left:20px;">${lis}</ul>`;
+}
+
+function renderParagraph(html, opts = {}) {
+  const colour = opts.muted ? BRAND.inkSoft : BRAND.ink;
+  return `<p style="margin:0 0 12px;font-family:${BRAND.font};font-size:15px;line-height:1.6;color:${colour};">${html}</p>`;
+}
+
 // ── Welcome + plan ready ────────────────────────────────────────────────────
 
 export const sendWelcomeEmail = internalAction({
@@ -49,30 +83,38 @@ export const sendWelcomeEmail = internalAction({
     if (!ok) return;
 
     const resend = getResend();
-    const previewList =
-      data.week1Previews.length > 0
-        ? `<ul style="margin:12px 0;padding-left:20px;">${data.week1Previews.map((t) => `<li style="margin-bottom:6px;">${t}</li>`).join("")}</ul>`
-        : "";
+    const safeFirst = escapeHtml(data.firstName);
     const roleContext =
       data.roleTitle && data.companyName
-        ? ` as <strong>${data.roleTitle}</strong> at <strong>${data.companyName}</strong>`
+        ? ` as <strong>${escapeHtml(data.roleTitle)}</strong> at <strong>${escapeHtml(data.companyName)}</strong>`
         : data.roleTitle
-          ? ` as <strong>${data.roleTitle}</strong>`
+          ? ` as <strong>${escapeHtml(data.roleTitle)}</strong>`
           : "";
 
-    const html = `
-<div style="font-family:sans-serif;max-width:540px;margin:0 auto;color:#1a1a1a;">
-  <h2 style="margin-bottom:4px;">Your 90-day plan is ready, ${data.firstName}! 🎉</h2>
-  <p style="color:#555;margin-top:0;">Your personalised plan for starting${roleContext} has been built. Here's a sneak peek at week 1:</p>
-  ${previewList}
-  <p>Every morning you'll find your activities waiting on the Today page. Small, focused tasks — one day at a time.</p>
-  <a href="${APP_URL}/today" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600;margin:8px 0;">Go to today's plan →</a>
-  <p style="color:#888;font-size:13px;margin-top:24px;">You're receiving this because you just generated your First90 plan. <a href="${APP_URL}/settings" style="color:#888;">Manage notifications</a></p>
-</div>`;
+    const bodyHtml = `
+${renderParagraph(`Your personalised plan for starting${roleContext} is ready. Here's a sneak peek at week 1:`, { muted: true })}
+${renderBulletList(data.week1Previews)}
+${renderParagraph("Every morning you'll find that day's activities waiting on the Today page. Small, focused tasks — one day at a time.", { muted: true })}`;
+
+    const html = renderTemplate({
+      preheader: "Your personalised 90-day plan is ready — here's a peek at week 1",
+      appUrl: APP_URL,
+      productName: PRODUCT_NAME,
+      logoUrl: LOGO_URL,
+      heading: `Your 90-day plan is ready, ${safeFirst}! 🎉`,
+      bodyHtml,
+      ctaHref: `${APP_URL}/today`,
+      ctaLabel: "Go to today's plan →",
+    });
 
     const text = `Your 90-day plan is ready, ${data.firstName}!\n\nYour personalised plan has been built. Head to ${APP_URL}/today to see today's activities.\n\nManage notifications: ${APP_URL}/settings`;
 
-    await sendEmail(resend, { to: data.email, subject: "Your 90-day plan is ready 🎉", html, text });
+    await sendEmail(resend, {
+      to: data.email,
+      subject: `Your 90-day plan is ready 🎉`,
+      html,
+      text,
+    });
   },
 });
 
@@ -99,25 +141,36 @@ export const sendDailyReminderEmail = internalAction({
     if (!ok) return;
 
     const resend = getResend();
-    const activityList =
-      activities.titles.length > 0
-        ? `<ul style="margin:12px 0;padding-left:20px;">${activities.titles.map((t) => `<li style="margin-bottom:6px;">${t}</li>`).join("")}${activities.count > activities.titles.length ? `<li style="color:#888;">+ ${activities.count - activities.titles.length} more…</li>` : ""}</ul>`
+    const safeFirst = escapeHtml(user.firstName);
+    const more = activities.count - activities.titles.length;
+    const titlesHtml = renderBulletList(activities.titles);
+    const moreLine =
+      more > 0
+        ? `<p style="margin:0 0 12px;font-family:${BRAND.font};font-size:13px;color:${BRAND.muted};">+ ${more} more${more === 1 ? "" : ""} on Today.</p>`
         : "";
+    const countLabel = activities.count === 1 ? "activity" : "activities";
 
-    const html = `
-<div style="font-family:sans-serif;max-width:540px;margin:0 auto;color:#1a1a1a;">
-  <h2 style="margin-bottom:4px;">Good morning, ${user.firstName}!</h2>
-  <p style="color:#555;margin-top:0;">You have <strong>${activities.count} ${activities.count === 1 ? "activity" : "activities"}</strong> lined up for today:</p>
-  ${activityList}
-  <a href="${APP_URL}/today" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600;margin:8px 0;">Start your day →</a>
-  <p style="color:#888;font-size:13px;margin-top:24px;"><a href="${APP_URL}/settings" style="color:#888;">Manage notifications</a></p>
-</div>`;
+    const bodyHtml = `
+${renderParagraph(`You have <strong>${activities.count} ${countLabel}</strong> lined up for today:`, { muted: true })}
+${titlesHtml}
+${moreLine}`;
 
-    const text = `Good morning, ${user.firstName}!\n\nYou have ${activities.count} ${activities.count === 1 ? "activity" : "activities"} lined up for today.\n\nSee them at ${APP_URL}/today\n\nManage notifications: ${APP_URL}/settings`;
+    const html = renderTemplate({
+      preheader: `${activities.count} ${countLabel} ready for today`,
+      appUrl: APP_URL,
+      productName: PRODUCT_NAME,
+      logoUrl: LOGO_URL,
+      heading: `Good morning, ${safeFirst}`,
+      bodyHtml,
+      ctaHref: `${APP_URL}/today`,
+      ctaLabel: "Start your day →",
+    });
+
+    const text = `Good morning, ${user.firstName}!\n\nYou have ${activities.count} ${countLabel} lined up for today.\n\nSee them at ${APP_URL}/today\n\nManage notifications: ${APP_URL}/settings`;
 
     await sendEmail(resend, {
       to: user.email,
-      subject: `${activities.count} ${activities.count === 1 ? "activity" : "activities"} ready for today`,
+      subject: `${activities.count} ${countLabel} ready for today`,
       html,
       text,
     });
@@ -143,13 +196,22 @@ export const sendWeeklyReflectionEmail = internalAction({
     if (!ok) return;
 
     const resend = getResend();
-    const html = `
-<div style="font-family:sans-serif;max-width:540px;margin:0 auto;color:#1a1a1a;">
-  <h2 style="margin-bottom:4px;">Week ${data.weekNumber} is almost done, ${data.firstName}</h2>
-  <p style="color:#555;margin-top:0;">Take 5 minutes to reflect on your week. Weekly reviews are the best way to track what's working and course-correct before next week starts.</p>
-  <a href="${APP_URL}/reflect/weekly" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600;margin:8px 0;">Write your week ${data.weekNumber} reflection →</a>
-  <p style="color:#888;font-size:13px;margin-top:24px;"><a href="${APP_URL}/settings" style="color:#888;">Manage notifications</a></p>
-</div>`;
+    const safeFirst = escapeHtml(data.firstName);
+
+    const bodyHtml = `
+${renderParagraph(`Week ${data.weekNumber} is almost done. Take 5 minutes to reflect on what worked, what didn't, and what to course-correct before next week starts.`, { muted: true })}
+${renderParagraph("Weekly reviews are how the best onboarders stay on track — not by working harder, but by noticing patterns early.", { muted: true })}`;
+
+    const html = renderTemplate({
+      preheader: `Take 5 minutes to reflect on week ${data.weekNumber}`,
+      appUrl: APP_URL,
+      productName: PRODUCT_NAME,
+      logoUrl: LOGO_URL,
+      heading: `Week ${data.weekNumber} reflection time, ${safeFirst}`,
+      bodyHtml,
+      ctaHref: `${APP_URL}/reflect/weekly`,
+      ctaLabel: `Write your week ${data.weekNumber} reflection →`,
+    });
 
     const text = `Week ${data.weekNumber} is almost done, ${data.firstName}.\n\nTake 5 minutes to reflect at ${APP_URL}/reflect/weekly\n\nManage notifications: ${APP_URL}/settings`;
 
@@ -181,13 +243,24 @@ export const sendGoalApprovalRequestEmail = internalAction({
       if (!ok) continue;
 
       const planUrl = `${APP_URL}/shared/${data.planId}`;
-      const html = `
-<div style="font-family:sans-serif;max-width:540px;margin:0 auto;color:#1a1a1a;">
-  <h2 style="margin-bottom:4px;">Goal approval request from ${data.ownerName}</h2>
-  <p style="color:#555;margin-top:0;"><strong>${data.ownerName}</strong> has requested your sign-off on the following goal:</p>
-  <blockquote style="border-left:3px solid #2563eb;margin:12px 0;padding:8px 16px;background:#f0f4ff;border-radius:4px;font-size:15px;">${data.goalTitle}</blockquote>
-  <a href="${planUrl}" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600;margin:8px 0;">Review &amp; sign off →</a>
-</div>`;
+      const safeOwner = escapeHtml(data.ownerName);
+      const safeGoal = escapeHtml(data.goalTitle);
+
+      const bodyHtml = `
+${renderParagraph(`<strong>${safeOwner}</strong> has requested your sign-off on the following goal:`, { muted: true })}
+${renderQuote(safeGoal)}
+${renderParagraph("As their reviewer, you can approve, request changes, or leave a comment when you visit the plan.", { muted: true })}`;
+
+      const html = renderTemplate({
+        preheader: `${data.ownerName} wants your sign-off on a 90-day goal`,
+        appUrl: APP_URL,
+        productName: PRODUCT_NAME,
+        logoUrl: LOGO_URL,
+        heading: `${data.ownerName} needs your approval`,
+        bodyHtml,
+        ctaHref: planUrl,
+        ctaLabel: "Review &amp; sign off →",
+      });
 
       const text = `${data.ownerName} has requested your sign-off on a goal: "${data.goalTitle}"\n\nReview it at ${planUrl}`;
 
@@ -220,21 +293,33 @@ export const sendGoalDecisionEmail = internalAction({
 
     const resend = getResend();
     const isApproved = data.approvalStatus === "approved";
-    const statusLabel = isApproved ? "approved ✅" : "sent back with changes requested";
     const planUrl = `${APP_URL}/today`;
-    const noteHtml = data.approvalNote
-      ? `<blockquote style="border-left:3px solid #e5e7eb;margin:12px 0;padding:8px 16px;background:#f9fafb;border-radius:4px;font-size:14px;color:#444;">${data.approvalNote}</blockquote>`
-      : "";
+    const safeDecider = escapeHtml(data.deciderName);
+    const safeGoal = escapeHtml(data.goalTitle);
+    const safeNote = data.approvalNote ? escapeHtml(data.approvalNote) : "";
+    const noteBlock = safeNote ? renderNote(safeNote) : "";
 
-    const html = `
-<div style="font-family:sans-serif;max-width:540px;margin:0 auto;color:#1a1a1a;">
-  <h2 style="margin-bottom:4px;">Your goal has been ${statusLabel}</h2>
-  <p style="color:#555;margin-top:0;"><strong>${data.deciderName}</strong> has reviewed your goal:</p>
-  <blockquote style="border-left:3px solid #2563eb;margin:12px 0;padding:8px 16px;background:#f0f4ff;border-radius:4px;font-size:15px;">${data.goalTitle}</blockquote>
-  ${noteHtml}
-  <a href="${planUrl}" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600;margin:8px 0;">View your goals →</a>
-  <p style="color:#888;font-size:13px;margin-top:24px;"><a href="${APP_URL}/settings" style="color:#888;">Manage notifications</a></p>
-</div>`;
+    const heading = isApproved
+      ? `Your goal was approved ✅`
+      : `Changes requested on your goal`;
+
+    const bodyHtml = `
+${renderParagraph(`<strong>${safeDecider}</strong> has reviewed your goal:`, { muted: true })}
+${renderQuote(safeGoal)}
+${noteBlock}`;
+
+    const html = renderTemplate({
+      preheader: isApproved
+        ? `${data.deciderName} approved your goal`
+        : `${data.deciderName} requested changes on your goal`,
+      appUrl: APP_URL,
+      productName: PRODUCT_NAME,
+      logoUrl: LOGO_URL,
+      heading,
+      bodyHtml,
+      ctaHref: planUrl,
+      ctaLabel: "View your goals →",
+    });
 
     const text = `${data.deciderName} has ${isApproved ? "approved" : "sent back"} your goal: "${data.goalTitle}"${data.approvalNote ? `\n\nNote: ${data.approvalNote}` : ""}\n\nView your goals: ${planUrl}`;
 
@@ -269,24 +354,40 @@ export const sendManagerInviteEmail = internalAction({
 
     const resend = getResend();
     const inviteUrl = `${APP_URL}/invite/${data.token}`;
+    const safeOwner = escapeHtml(data.ownerName);
+    const safeRole = escapeHtml(data.role);
+    const safeRoleTitle = data.roleTitle ? escapeHtml(data.roleTitle) : "";
+    const safeCompany = data.companyName ? escapeHtml(data.companyName) : "";
+
     const contextLine =
-      data.roleTitle && data.companyName
-        ? `${data.ownerName} is building their 90-day plan as <strong>${data.roleTitle}</strong> at <strong>${data.companyName}</strong> and has invited you to collaborate as their ${data.role}.`
-        : `${data.ownerName} has invited you to collaborate on their 90-day onboarding plan as their ${data.role}.`;
+      safeRoleTitle && safeCompany
+        ? `${safeOwner} is building their 90-day plan as <strong>${safeRoleTitle}</strong> at <strong>${safeCompany}</strong> and has invited you to collaborate as their ${safeRole}.`
+        : `${safeOwner} has invited you to collaborate on their 90-day onboarding plan as their ${safeRole}.`;
 
-    const messageBlock = data.message
-      ? `<blockquote style="border-left:3px solid #e5e7eb;margin:12px 0;padding:8px 16px;background:#f9fafb;border-radius:4px;font-size:14px;color:#444;">${data.message}</blockquote>`
-      : "";
+    const messageBlock = data.message ? renderNote(escapeHtml(data.message)) : "";
 
-    const html = `
-<div style="font-family:sans-serif;max-width:540px;margin:0 auto;color:#1a1a1a;">
-  <h2 style="margin-bottom:4px;">${data.ownerName} invited you to their 90-day plan</h2>
-  <p style="color:#555;margin-top:0;">${contextLine}</p>
-  ${messageBlock}
-  <p>As their ${data.role}, you can view their plan, leave comments, and sign off on goals.</p>
-  <a href="${inviteUrl}" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600;margin:8px 0;">Accept invitation →</a>
-  <p style="color:#888;font-size:13px;margin-top:24px;">This invitation expires in 14 days.</p>
+    const explainerHtml = `<div style="margin:18px 0;padding:14px 16px;background:${BRAND.bg};border:1px solid ${BRAND.cardBorder};border-radius:10px;font-family:${BRAND.font};font-size:13px;line-height:1.5;color:${BRAND.inkSoft};">
+<strong style="color:${BRAND.ink};">What is ${escapeHtml(PRODUCT_NAME)}?</strong> A workspace that helps people starting a new role build a personalised 30/60/90 plan and stay aligned with their manager.
 </div>`;
+
+    const bodyHtml = `
+${renderParagraph(contextLine, { muted: true })}
+${messageBlock}
+${renderParagraph(`As their ${safeRole}, you can review the plan, leave comments, and sign off on goals.`, { muted: true })}
+${explainerHtml}`;
+
+    const html = renderTemplate({
+      preheader: `${data.ownerName} invited you to review their 90-day plan`,
+      appUrl: APP_URL,
+      productName: PRODUCT_NAME,
+      logoUrl: LOGO_URL,
+      heading: `${data.ownerName} invited you to their 90-day plan`,
+      bodyHtml,
+      ctaHref: inviteUrl,
+      ctaLabel: "Accept invitation →",
+      showManageNotifications: false,
+      footerNote: "This invitation expires in 14 days.",
+    });
 
     const text = `${data.ownerName} has invited you to their 90-day onboarding plan as their ${data.role}.\n\nAccept the invitation: ${inviteUrl}\n\nThis invitation expires in 14 days.`;
 
@@ -321,15 +422,23 @@ export const sendPlanCommentEmail = internalAction({
       const targetLabel = data.targetType === "plan" ? "the plan" : `a ${data.targetType}`;
       const preview =
         data.body.length > 120 ? data.body.slice(0, 120).trimEnd() + "…" : data.body;
+      const safeAuthor = escapeHtml(data.authorName);
+      const safePreview = escapeHtml(preview);
 
-      const html = `
-<div style="font-family:sans-serif;max-width:540px;margin:0 auto;color:#1a1a1a;">
-  <h2 style="margin-bottom:4px;">New comment from ${data.authorName}</h2>
-  <p style="color:#555;margin-top:0;"><strong>${data.authorName}</strong> left a comment on ${targetLabel}:</p>
-  <blockquote style="border-left:3px solid #2563eb;margin:12px 0;padding:8px 16px;background:#f0f4ff;border-radius:4px;font-size:15px;">${preview}</blockquote>
-  <a href="${planUrl}" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600;margin:8px 0;">View comment →</a>
-  <p style="color:#888;font-size:13px;margin-top:24px;"><a href="${APP_URL}/settings" style="color:#888;">Manage notifications</a></p>
-</div>`;
+      const bodyHtml = `
+${renderParagraph(`<strong>${safeAuthor}</strong> left a comment on ${escapeHtml(targetLabel)}:`, { muted: true })}
+${renderQuote(safePreview)}`;
+
+      const html = renderTemplate({
+        preheader: `${data.authorName} commented: ${preview}`,
+        appUrl: APP_URL,
+        productName: PRODUCT_NAME,
+        logoUrl: LOGO_URL,
+        heading: `New comment from ${data.authorName}`,
+        bodyHtml,
+        ctaHref: planUrl,
+        ctaLabel: "View comment →",
+      });
 
       const text = `${data.authorName} commented on ${targetLabel}:\n\n"${preview}"\n\nView it at ${planUrl}\n\nManage notifications: ${APP_URL}/settings`;
 

--- a/convex/emailChangeActions.js
+++ b/convex/emailChangeActions.js
@@ -3,8 +3,29 @@
 import { v } from "convex/values";
 import { internalAction } from "./_generated/server";
 import { Resend } from "resend";
+import { renderEmailShell, renderCodeBlock, BRAND } from "./lib/emailLayout";
 
-const FROM_ADDRESS = process.env.AUTH_EMAIL ?? "First90 <onboarding@resend.dev>";
+const FROM_ADDRESS = process.env.AUTH_EMAIL ?? "First90 <hello@switchtoux.com>";
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.first90days.com";
+const PRODUCT_NAME = process.env.PRODUCT_NAME ?? "First90";
+const LOGO_URL = process.env.EMAIL_LOGO_URL ?? "";
+
+function buildEmailChangeHtml(code) {
+  const inner = `
+<h1 style="margin:0 0 8px;font-family:${BRAND.font};font-size:22px;line-height:1.3;font-weight:700;color:${BRAND.ink};">Confirm your new email</h1>
+<p style="margin:0 0 8px;font-family:${BRAND.font};font-size:15px;line-height:1.6;color:${BRAND.inkSoft};">Enter this 8-digit code in your account settings to finish changing your email address:</p>
+${renderCodeBlock(code)}
+<p style="margin:0 0 8px;font-family:${BRAND.font};font-size:14px;line-height:1.6;color:${BRAND.inkSoft};">This code expires in 20 minutes.</p>
+<p style="margin:0;font-family:${BRAND.font};font-size:14px;line-height:1.6;color:${BRAND.muted};">If you didn't request an email change, you can safely ignore this email — your account stays unchanged.</p>`;
+  return renderEmailShell({
+    preheader: `Confirm your new ${PRODUCT_NAME} email`,
+    appUrl: APP_URL,
+    productName: PRODUCT_NAME,
+    logoUrl: LOGO_URL,
+    innerHtml: inner,
+    showManageNotifications: false,
+  });
+}
 
 export const sendVerificationEmail = internalAction({
   args: { email: v.string(), code: v.string() },
@@ -23,12 +44,14 @@ export const sendVerificationEmail = internalAction({
     const { error } = await resend.emails.send({
       from: FROM_ADDRESS,
       to: [email],
-      subject: "Confirm your new email address",
+      subject: `Confirm your new ${PRODUCT_NAME} email`,
+      html: buildEmailChangeHtml(code),
       text: [
-        `Your First90 email change verification code is: ${code}`,
+        `Your ${PRODUCT_NAME} email change verification code is: ${code}`,
         "",
-        "Enter this code in your settings to confirm the email change.",
-        "This code expires in 20 minutes. If you didn't request this change, you can safely ignore this email.",
+        "Enter this code in your account settings to confirm the email change. It expires in 20 minutes.",
+        "",
+        "If you didn't request this change, you can safely ignore this email.",
       ].join("\n"),
     });
     if (error) {

--- a/convex/lib/emailLayout.js
+++ b/convex/lib/emailLayout.js
@@ -1,0 +1,215 @@
+/**
+ * Shared email layout + brand primitives for all transactional + lifecycle
+ * emails sent through Resend.
+ *
+ * Why this file exists:
+ *  - Until we built this, every email re-implemented its own HTML wrapper
+ *    with hard-coded colours and an inconsistent footer. Auth emails were
+ *    plain text only. CTA buttons used #2563eb (a generic blue) instead of
+ *    the app's #D97757 accent.
+ *  - One place to update the brand → all emails inherit consistently.
+ *  - Product-name-agnostic strings ("Your verification code") so the
+ *    in-flight First90 → Arcora rename in another branch can fill in the
+ *    wordmark without touching layout.
+ *
+ * All helpers are pure string builders. No imports, no side effects, so
+ * this is safe to load from any Convex Node action or query.
+ */
+
+// Brand tokens — match the in-app dashboard.
+export const BRAND = Object.freeze({
+  // Surfaces (kept on a light/cream background so emails render well in
+  // every client, even those without dark-mode CSS support).
+  bg: "#F5F1EA",
+  card: "#FFFFFF",
+  cardBorder: "#E7E5E4",
+  ink: "#1C1917",
+  inkSoft: "#57534E",
+  muted: "#A8A29E",
+  // Accent + actions.
+  accent: "#D97757",
+  accentHover: "#C26242",
+  accentSurface: "#FBE9DF",
+  // Hairline divider colour for the footer.
+  rule: "#E7E5E4",
+  // Email-safe font stack. Inter is preferred when available; we fall back
+  // through the standard system stack so plain Outlook still looks clean.
+  font:
+    "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
+});
+
+/**
+ * Tiny helper to escape user-supplied strings before injecting them into
+ * an email template. Defends against an attacker putting `<script>` tags
+ * into their first name and us blasting that to a manager's inbox.
+ *
+ * Resend's HTML is rendered, so the same XSS rules apply as the web.
+ */
+export function escapeHtml(input) {
+  if (input === undefined || input === null) return "";
+  return String(input)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Render a primary call-to-action button. Inline styles only — Gmail,
+ * Outlook, etc. routinely strip <style> blocks.
+ */
+export function renderButton(href, label) {
+  const safeLabel = escapeHtml(label);
+  return `<a href="${href}" style="display:inline-block;background:${BRAND.accent};color:#FFFFFF;padding:12px 22px;border-radius:8px;text-decoration:none;font-weight:600;font-size:15px;line-height:1;margin:18px 0;font-family:${BRAND.font};">${safeLabel}</a>`;
+}
+
+/**
+ * Centred, big numeric code block — used for verification + password
+ * reset emails. Many clients (Apple Mail, Gmail mobile) auto-detect
+ * monospace OTP-style numbers and surface them as quick-fill chips.
+ */
+export function renderCodeBlock(code) {
+  const safeCode = escapeHtml(code);
+  return `
+<div style="margin:24px 0;padding:18px 16px;background:${BRAND.accentSurface};border:1px solid ${BRAND.accent}33;border-radius:12px;text-align:center;">
+  <div style="font-family:'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;font-size:32px;font-weight:600;letter-spacing:6px;color:${BRAND.ink};">${safeCode}</div>
+</div>`;
+}
+
+/**
+ * Block-quote treatment — used to surface user-generated content
+ * (goal titles, comment previews, invitation messages) inline.
+ */
+export function renderQuote(content) {
+  // content is HTML — caller is responsible for escaping any
+  // user-supplied text BEFORE passing it in.
+  return `<blockquote style="border-left:3px solid ${BRAND.accent};margin:14px 0;padding:10px 16px;background:${BRAND.accentSurface};border-radius:6px;font-size:15px;line-height:1.5;color:${BRAND.ink};font-family:${BRAND.font};">${content}</blockquote>`;
+}
+
+/**
+ * Soft note treatment — secondary blockquote for things like
+ * "Note from your manager:" decisions or user messages that should look
+ * less prominent than the primary content.
+ */
+export function renderNote(content) {
+  return `<blockquote style="border-left:3px solid ${BRAND.cardBorder};margin:14px 0;padding:10px 16px;background:${BRAND.bg};border-radius:6px;font-size:14px;line-height:1.5;color:${BRAND.inkSoft};font-family:${BRAND.font};">${content}</blockquote>`;
+}
+
+/**
+ * Wrap any inner HTML in the canonical email shell:
+ *   - hidden preheader (~80 chars in inbox preview)
+ *   - branded header
+ *   - card with the content
+ *   - footer
+ *
+ * `appUrl` is required so the footer's "manage notifications" link works
+ * even when consumers are loaded from environments where
+ * NEXT_PUBLIC_APP_URL might not be set.
+ */
+export function renderEmailShell({
+  preheader = "",
+  appUrl,
+  productName = "First90",
+  logoUrl = "",
+  innerHtml,
+  showManageNotifications = true,
+  footerNote = "",
+}) {
+  const safePreheader = escapeHtml(preheader);
+  const safeProduct = escapeHtml(productName);
+  const settingsUrl = `${appUrl}/settings`;
+
+  // Logo: use an <img> when a URL is provided (the marketing site or a
+  // public CDN). Otherwise we fall back to a textual wordmark in the
+  // brand accent. Keeping this logoUrl-toggleable means we can flip on a
+  // hosted logo later without redeploying the email layout.
+  const headerMark = logoUrl
+    ? `<img src="${logoUrl}" alt="${safeProduct}" width="120" style="display:block;max-width:160px;height:auto;border:0;outline:none;" />`
+    : `<span style="font-family:${BRAND.font};font-weight:700;font-size:20px;color:${BRAND.accent};letter-spacing:-0.2px;">${safeProduct}</span>`;
+
+  const manageBlock = showManageNotifications
+    ? `<a href="${settingsUrl}" style="color:${BRAND.muted};text-decoration:underline;">Manage notifications</a>`
+    : "";
+
+  const footerExtraBlock = footerNote
+    ? `<p style="margin:0 0 8px;color:${BRAND.muted};font-size:12px;line-height:1.5;font-family:${BRAND.font};">${footerNote}</p>`
+    : "";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="color-scheme" content="light" />
+  <meta name="supported-color-schemes" content="light" />
+  <title>${safeProduct}</title>
+</head>
+<body style="margin:0;padding:0;background:${BRAND.bg};font-family:${BRAND.font};color:${BRAND.ink};">
+  <!-- Hidden preheader: shows in inbox preview, never in the body. -->
+  <div style="display:none;max-height:0;overflow:hidden;mso-hide:all;font-size:1px;line-height:1px;color:${BRAND.bg};opacity:0;">${safePreheader}</div>
+
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:${BRAND.bg};">
+    <tr>
+      <td align="center" style="padding:32px 16px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;">
+          <tr>
+            <td style="padding:0 4px 18px;">
+              ${headerMark}
+            </td>
+          </tr>
+          <tr>
+            <td style="background:${BRAND.card};border:1px solid ${BRAND.cardBorder};border-radius:14px;padding:32px 28px;">
+              ${innerHtml}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:18px 4px 0;">
+              <hr style="border:0;border-top:1px solid ${BRAND.rule};margin:0 0 14px;" />
+              ${footerExtraBlock}
+              <p style="margin:0;color:${BRAND.muted};font-size:12px;line-height:1.5;font-family:${BRAND.font};">
+                Sent by ${safeProduct} &middot; your AI onboarding companion${manageBlock ? ` &middot; ${manageBlock}` : ""}
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+/**
+ * Convenience wrapper: builds a full HTML email from a heading + body
+ * markup, plus a primary CTA. Most lifecycle emails fit this shape.
+ */
+export function renderTemplate({
+  preheader,
+  appUrl,
+  productName,
+  logoUrl,
+  heading,
+  bodyHtml,
+  ctaHref,
+  ctaLabel,
+  showManageNotifications = true,
+  footerNote = "",
+}) {
+  const safeHeading = escapeHtml(heading);
+  const ctaBlock = ctaHref && ctaLabel ? renderButton(ctaHref, ctaLabel) : "";
+  const inner = `
+<h1 style="margin:0 0 12px;font-family:${BRAND.font};font-size:22px;line-height:1.3;font-weight:700;color:${BRAND.ink};">${safeHeading}</h1>
+${bodyHtml}
+${ctaBlock}`;
+
+  return renderEmailShell({
+    preheader,
+    appUrl,
+    productName,
+    logoUrl,
+    innerHtml: inner,
+    showManageNotifications,
+    footerNote,
+  });
+}


### PR DESCRIPTION
## Why

Audit on 2026-04-25 surfaced three issues with outgoing email:

1. **Auth emails were plain text only.** Verification, password reset and email change all looked like phishing — no header, no logo, no branding.
2. **CTA buttons were blue (#2563eb).** Doesn't match the app's orange accent (#D97757).
3. **Sender address drifted between files.** Auth and lifecycle defaulted to different addresses when AUTH_EMAIL was missing on Convex prod.

## What's in this PR

### New: `convex/lib/emailLayout.js`

Single source of truth for email branding. Exports:

- BRAND tokens
- escapeHtml — must wrap all user-supplied strings before interpolation
- renderButton, renderCodeBlock, renderQuote, renderNote
- renderEmailShell — hidden preheader, header (logo or wordmark), card, footer
- renderTemplate — convenience wrapper for the heading + body + CTA pattern most emails follow

Inline styles only (Gmail and Outlook strip <style> blocks). Light theme by design so it renders reliably across clients without dark-mode CSS support.

### Updated: 10 email templates across 4 files

| File | Templates touched |
|---|---|
| convex/ResendOTP.js | Verification code |
| convex/ResendOTPPasswordReset.js | Password reset code |
| convex/emailChangeActions.js | Email change confirmation |
| convex/emailActions.js | Welcome, daily reminder, weekly reflection, goal approval request, goal decision, manager invite, plan comment |

All three auth emails now ship with proper HTML. Big centred 8-digit code block in the brand accent. Plain-text fallback preserved.

All seven lifecycle emails refactored to use renderTemplate. CTA colour flipped from #2563eb to #D97757.

### Other fixes

- All three sender files now default to `First90 <hello@switchtoux.com>` so we have one canonical sender even when AUTH_EMAIL is unset.
- User-supplied strings (names, role titles, comment bodies, goal titles, invite messages) all flow through escapeHtml before rendering.
- Manager invite now includes a 'What is First90?' explainer block — recipient probably hasn't heard of the product.
- Hidden preheader text on every email for better inbox previews.

### Rebrand-ready

Product name and logo are env-driven (PRODUCT_NAME, EMAIL_LOGO_URL). The in-flight First90 → Arcora rename can flip the wordmark by setting two env vars. No code changes needed when the new branch lands.

## Verification

- pnpm lint clean
- No behaviour changes outside the visual layer
- Plain-text fallbacks preserved on every email

## Out of scope

- Hosting the actual logo (waiting on Rulz to provide a URL — the layout already renders a textual wordmark in the meantime).
- Migrating sender domain to usearcora.com or first90days.com — keeping switchtoux.com per Rulz's call until the product is making money.
- Email-side dark mode support — modern Apple Mail does basic auto-dark, but a true dark-mode-aware template is post-launch.

🦀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Transactional and lifecycle emails now display with branded HTML formatting, including styled code blocks for verification codes, consistent layouts with professional typography, and improved visual hierarchy across all email types: verification, password reset, welcome messages, reminders, reflections, approvals, invitations, and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->