### PR TITLE
feat(legal+og): Terms, Privacy, OG image — launch readiness

### DIFF
--- a/src/app/(legal)/layout.js
+++ b/src/app/(legal)/layout.js
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { Icon } from "@iconify/react";
+
+// Standalone layout for the public Terms / Privacy pages so they don't
+// inherit the dashboard chrome and can render readably on cold visits
+// (e.g. someone clicking through from the footer or an email).
+//
+// Uses the same paper background + ink palette as the marketing site for
+// visual consistency, but no nav/auth guards.
+
+export default function LegalLayout({ children }) {
+  return (
+    <div className="min-h-screen bg-[#F5F2E8] dark:bg-[#0F0E0D] text-[#1C1917] dark:text-[#E7E5E4]">
+      <header className="border-b border-[#D1CDC7] dark:border-[#2C2825]">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
+          <Link
+            href="/"
+            className="flex items-center gap-2 font-space-grotesk text-sm font-semibold"
+            aria-label="Arcora home"
+          >
+            <Icon icon="solar:stars-minimalistic-linear" className="text-accent" width={18} />
+            Arcora
+          </Link>
+          <Link
+            href="/"
+            className="font-space-grotesk text-xs text-[#57534E] dark:text-[#A8A29E] hover:text-accent transition-colors"
+          >
+            ← Back to site
+          </Link>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 py-10 sm:py-14">
+        <article className="prose-arcora">{children}</article>
+      </main>
+
+      <footer className="border-t border-[#D1CDC7] dark:border-[#2C2825] py-6">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row gap-3 items-center justify-between text-xs text-[#78716C] font-space-grotesk">
+          <p>© {new Date().getFullYear()} Rulz &amp; Co</p>
+          <div className="flex gap-5">
+            <Link href="/terms" className="hover:text-accent transition-colors">
+              Terms
+            </Link>
+            <Link href="/privacy" className="hover:text-accent transition-colors">
+              Privacy
+            </Link>
+            <a
+              href="mailto:legal@usearcora.com"
+              className="hover:text-accent transition-colors"
+            >
+              legal@usearcora.com
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/(legal)/privacy/page.js
+++ b/src/app/(legal)/privacy/page.js
@@ -1,0 +1,400 @@
+// Privacy Policy — Arcora
+// Last reviewed: 2026-05-02
+//
+// Drafted to be UK GDPR + EEA GDPR friendly for a solo-built SaaS. Lists
+// concrete sub-processors actually wired into the codebase (Convex,
+// Stripe, Resend, Anthropic, OpenAI, Vercel, Beehiiv, Upstash). Plain
+// English where possible.
+//
+// Not legal advice. Rulz reviewed and approved the scope.
+
+import Link from "next/link";
+
+export const metadata = {
+  title: "Privacy Policy · Arcora",
+  description:
+    "How Arcora collects, uses, shares, and protects your information.",
+  alternates: { canonical: "/privacy" },
+};
+
+const SECTIONS = [
+  { id: "overview", label: "Overview" },
+  { id: "controller", label: "Who is the data controller?" },
+  { id: "what-we-collect", label: "What we collect" },
+  { id: "how-we-use", label: "How we use it" },
+  { id: "lawful-basis", label: "Lawful basis (UK / EU)" },
+  { id: "ai-data", label: "AI processing of your data" },
+  { id: "subprocessors", label: "Sub-processors" },
+  { id: "sharing", label: "Sharing your information" },
+  { id: "retention", label: "Retention" },
+  { id: "security", label: "Security" },
+  { id: "your-rights", label: "Your rights" },
+  { id: "international", label: "International transfers" },
+  { id: "cookies", label: "Cookies and tracking" },
+  { id: "children", label: "Children's privacy" },
+  { id: "changes", label: "Changes to this policy" },
+  { id: "contact", label: "Contact" },
+];
+
+const containerCls = "mb-6 leading-relaxed";
+const headingCls = "scroll-mt-20 mt-10 mb-3 font-instrument-serif text-2xl";
+const bodyCls = "text-[#1C1917] dark:text-[#E7E5E4]";
+
+function H2({ id, children }) {
+  return (
+    <h2 id={id} className={headingCls}>
+      {children}
+    </h2>
+  );
+}
+function P({ children }) {
+  return <p className={`${containerCls} ${bodyCls}`}>{children}</p>;
+}
+function UL({ children }) {
+  return <ul className="list-disc pl-6 mb-6 space-y-1.5">{children}</ul>;
+}
+
+const SUBPROCESSORS = [
+  {
+    name: "Convex",
+    purpose: "Application database and backend functions",
+    location: "United States",
+    link: "https://www.convex.dev/legal/privacy",
+  },
+  {
+    name: "Vercel",
+    purpose: "Web app hosting and edge networking",
+    location: "United States",
+    link: "https://vercel.com/legal/privacy-policy",
+  },
+  {
+    name: "Stripe",
+    purpose: "Payment processing for the Pro subscription",
+    location: "United States / United Kingdom",
+    link: "https://stripe.com/privacy",
+  },
+  {
+    name: "Resend",
+    purpose: "Transactional email (verification codes, plan-ready, reminders, invitations)",
+    location: "United States",
+    link: "https://resend.com/legal/privacy-policy",
+  },
+  {
+    name: "Anthropic (Claude)",
+    purpose: "AI generation of plans, milestones, and analysis",
+    location: "United States",
+    link: "https://www.anthropic.com/legal/privacy",
+  },
+  {
+    name: "OpenAI",
+    purpose: "AI generation and embeddings for knowledge-base search",
+    location: "United States",
+    link: "https://openai.com/policies/privacy-policy/",
+  },
+  {
+    name: "Upstash (optional)",
+    purpose: "Distributed rate limiting",
+    location: "United States",
+    link: "https://upstash.com/trust/privacy.pdf",
+  },
+  {
+    name: "Beehiiv (optional)",
+    purpose: "Newsletter and waitlist email delivery",
+    location: "United States",
+    link: "https://www.beehiiv.com/privacy",
+  },
+];
+
+export default function PrivacyPage() {
+  return (
+    <div className="font-space-grotesk text-[15px]">
+      <h1 className="font-instrument-serif text-4xl sm:text-5xl mb-3">
+        Privacy Policy
+      </h1>
+      <p className="text-sm text-[#57534E] dark:text-[#A8A29E] mb-8">
+        Last updated: 2 May 2026
+      </p>
+
+      <P>
+        This Privacy Policy explains what information{" "}
+        <strong>Arcora</strong> (the &ldquo;<strong>Service</strong>
+        &rdquo;), provided by <strong>Rulz &amp; Co</strong> (&ldquo;
+        <strong>we</strong>&rdquo;, &ldquo;<strong>us</strong>&rdquo;)
+        collects when you use it, how we use that information, who we
+        share it with, and what rights you have.
+      </P>
+
+      <nav
+        aria-label="On this page"
+        className="border border-[#D1CDC7] dark:border-[#2C2825] rounded-xl p-4 mb-10 bg-white/60 dark:bg-[#1C1917]/60"
+      >
+        <p className="text-xs uppercase tracking-wider text-[#78716C] mb-2">
+          On this page
+        </p>
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-sm">
+          {SECTIONS.map((s) => (
+            <li key={s.id}>
+              <a
+                href={`#${s.id}`}
+                className="text-[#57534E] dark:text-[#A8A29E] hover:text-accent transition-colors"
+              >
+                {s.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <H2 id="overview">1. Overview</H2>
+      <P>
+        Arcora is a workspace that helps people in their first 90 days at
+        a new job. To do that we need to know things like your role,
+        company name, manager, and goals. We try to collect the minimum
+        we need to run the Service well, and to be transparent about
+        what happens with that data.
+      </P>
+      <UL>
+        <li>We do not sell your personal data.</li>
+        <li>We do not train AI models on your data.</li>
+        <li>You can export and delete your data at any time.</li>
+      </UL>
+
+      <H2 id="controller">2. Who is the data controller?</H2>
+      <P>
+        The data controller is <strong>Rulz &amp; Co</strong>, based in
+        Manchester, United Kingdom. You can reach the controller at{" "}
+        <a
+          href="mailto:legal@usearcora.com"
+          className="text-accent underline"
+        >
+          legal@usearcora.com
+        </a>
+        .
+      </P>
+
+      <H2 id="what-we-collect">3. What we collect</H2>
+      <P>We collect three categories of information:</P>
+      <UL>
+        <li>
+          <strong>Account info</strong>: name, email, password (stored
+          hashed), profile photo if you upload one, and authentication
+          metadata such as session timestamps and recent IP addresses
+          (for security and account-lockout protection).
+        </li>
+        <li>
+          <strong>Plan data</strong>: information you provide when
+          building your 90-day plan — role title, company name, function,
+          start date, work model, goals, success definition,
+          stakeholders, knowledge-base notes, journal entries, and any
+          documents (e.g. job description) you choose to upload.
+        </li>
+        <li>
+          <strong>Usage data</strong>: how you interact with the Service
+          (page views, feature usage, errors). We use this to improve the
+          product. We may use a privacy-friendly analytics service (e.g.
+          PostHog or Plausible) configured to avoid tracking
+          cross-product identifiers.
+        </li>
+      </UL>
+      <P>
+        Billing payment details (card numbers) are handled directly by
+        Stripe. We never see or store full card details — only the last
+        four digits and brand for receipt display.
+      </P>
+
+      <H2 id="how-we-use">4. How we use it</H2>
+      <UL>
+        <li>To create your account and authenticate you.</li>
+        <li>To generate your personalised 90-day plan and the related milestones, prompts, and insights.</li>
+        <li>To deliver transactional emails (verification, password reset, plan-ready, daily reminders, weekly reflections, manager invites, and so on).</li>
+        <li>To process and manage your Pro subscription if you choose to upgrade.</li>
+        <li>To respond to support requests.</li>
+        <li>To detect, investigate, and prevent abuse, fraud, and security incidents.</li>
+        <li>To comply with legal obligations.</li>
+      </UL>
+
+      <H2 id="lawful-basis">5. Lawful basis (UK / EU)</H2>
+      <P>If UK GDPR or EU GDPR applies to you, we rely on:</P>
+      <UL>
+        <li>
+          <strong>Performance of a contract</strong> — to provide the
+          Service you signed up for.
+        </li>
+        <li>
+          <strong>Legitimate interests</strong> — to keep the Service
+          secure, to prevent abuse, and to improve the product. These
+          interests are balanced against your rights and freedoms.
+        </li>
+        <li>
+          <strong>Consent</strong> — for optional features like the
+          newsletter signup. You can withdraw consent at any time.
+        </li>
+        <li>
+          <strong>Legal obligation</strong> — where law requires us to
+          retain or disclose data (for example, tax records).
+        </li>
+      </UL>
+
+      <H2 id="ai-data">6. AI processing of your data</H2>
+      <P>
+        Arcora generates plans and other personalised content using
+        third-party AI providers — currently <strong>Anthropic</strong>{" "}
+        (Claude) and <strong>OpenAI</strong>. To produce useful output,
+        we send relevant parts of your plan data and uploaded documents
+        to these providers as part of API requests.
+      </P>
+      <UL>
+        <li>Both providers are bound by their data processing agreements with us.</li>
+        <li>Neither provider trains their general-purpose models on data we send through their APIs.</li>
+        <li>Your data is sent over encrypted HTTPS connections.</li>
+        <li>You can review and delete the inputs at any time by editing or removing your plan content.</li>
+      </UL>
+
+      <H2 id="subprocessors">7. Sub-processors</H2>
+      <P>
+        We use the following third-party services to run Arcora. Each one
+        only receives the data necessary for its function.
+      </P>
+      <div className="overflow-x-auto mb-8">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr className="text-left">
+              <th className="border-b border-[#D1CDC7] dark:border-[#2C2825] py-2 pr-4 font-medium text-[#57534E] dark:text-[#A8A29E]">Provider</th>
+              <th className="border-b border-[#D1CDC7] dark:border-[#2C2825] py-2 pr-4 font-medium text-[#57534E] dark:text-[#A8A29E]">Purpose</th>
+              <th className="border-b border-[#D1CDC7] dark:border-[#2C2825] py-2 pr-4 font-medium text-[#57534E] dark:text-[#A8A29E]">Location</th>
+            </tr>
+          </thead>
+          <tbody>
+            {SUBPROCESSORS.map((sp) => (
+              <tr key={sp.name}>
+                <td className="border-b border-[#E7E5E4] dark:border-[#2C2825]/60 py-2.5 pr-4 align-top">
+                  <a
+                    href={sp.link}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-accent underline"
+                  >
+                    {sp.name}
+                  </a>
+                </td>
+                <td className="border-b border-[#E7E5E4] dark:border-[#2C2825]/60 py-2.5 pr-4 align-top">
+                  {sp.purpose}
+                </td>
+                <td className="border-b border-[#E7E5E4] dark:border-[#2C2825]/60 py-2.5 pr-4 align-top">
+                  {sp.location}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <P>
+        We&apos;ll update this list when we add or remove sub-processors
+        and notify users of material changes via email.
+      </P>
+
+      <H2 id="sharing">8. Sharing your information</H2>
+      <P>We share information only:</P>
+      <UL>
+        <li>With sub-processors as described above.</li>
+        <li>With managers and collaborators you explicitly invite (and only the parts of your plan you choose to share).</li>
+        <li>To comply with valid legal requests (court orders, lawful subpoenas).</li>
+        <li>To protect rights, property, or safety where necessary.</li>
+        <li>If we ever go through a sale, merger, or asset transfer, with notice to you.</li>
+      </UL>
+      <P>We don&apos;t sell your personal data, and we don&apos;t share it with advertisers.</P>
+
+      <H2 id="retention">9. Retention</H2>
+      <UL>
+        <li>Active accounts: data retained while your account is active.</li>
+        <li>Account deletion: data deleted or anonymised within 90 days.</li>
+        <li>Billing records: kept for at least 6 years where required by tax law.</li>
+        <li>Inactive accounts (12+ months no login): we may delete or anonymise data after notifying you by email.</li>
+      </UL>
+
+      <H2 id="security">10. Security</H2>
+      <P>
+        We use TLS in transit, encrypted databases at rest (managed by
+        Convex), bcrypt-hashed passwords, account-lockout protection, and
+        single-use email codes for sensitive actions. No system is 100%
+        secure, but we follow industry-standard practices and review them
+        regularly.
+      </P>
+
+      <H2 id="your-rights">11. Your rights</H2>
+      <P>If UK GDPR or EU GDPR applies, you have the right to:</P>
+      <UL>
+        <li>Access the personal data we hold about you.</li>
+        <li>Correct inaccurate or incomplete data.</li>
+        <li>Delete your data (subject to legal-retention exceptions).</li>
+        <li>Restrict or object to processing in certain circumstances.</li>
+        <li>Receive a copy of your data in a portable format.</li>
+        <li>Withdraw consent where processing is based on consent.</li>
+        <li>Lodge a complaint with the UK Information Commissioner&apos;s Office (<a href="https://ico.org.uk/" className="text-accent underline" target="_blank" rel="noreferrer">ico.org.uk</a>) or your local data protection authority.</li>
+      </UL>
+      <P>
+        To exercise any of these rights, email{" "}
+        <a
+          href="mailto:legal@usearcora.com"
+          className="text-accent underline"
+        >
+          legal@usearcora.com
+        </a>
+        . We&apos;ll respond within 30 days.
+      </P>
+
+      <H2 id="international">12. International transfers</H2>
+      <P>
+        Some of our sub-processors are located outside the UK / EEA
+        (mostly in the United States). Where we transfer personal data
+        internationally, we rely on Standard Contractual Clauses or
+        equivalent safeguards, as offered by those providers&apos; data
+        processing agreements.
+      </P>
+
+      <H2 id="cookies">13. Cookies and tracking</H2>
+      <P>
+        We use a small number of strictly necessary cookies to keep you
+        signed in and to remember your settings (e.g. dark-mode
+        preference). We do not use advertising cookies and we do not
+        track you across other websites.
+      </P>
+      <P>
+        If we add product analytics, we will use a privacy-friendly
+        provider configured to avoid persistent cross-site tracking, and
+        we&apos;ll update this section before turning it on.
+      </P>
+
+      <H2 id="children">14. Children&apos;s privacy</H2>
+      <P>
+        Arcora is not intended for children under 18. We do not knowingly
+        collect personal data from children. If you believe a child has
+        provided us with personal data, contact us and we&apos;ll delete
+        it.
+      </P>
+
+      <H2 id="changes">15. Changes to this policy</H2>
+      <P>
+        We may update this policy. If we make material changes,
+        we&apos;ll notify you by email or in-app at least 14 days before
+        the change takes effect. The &ldquo;Last updated&rdquo; date at
+        the top will always reflect the most recent revision.
+      </P>
+
+      <H2 id="contact">16. Contact</H2>
+      <P>
+        Questions about this policy or your data?{" "}
+        <a
+          href="mailto:legal@usearcora.com"
+          className="text-accent underline"
+        >
+          legal@usearcora.com
+        </a>
+      </P>
+
+      <p className="mt-12 mb-4 text-sm text-[#78716C]">
+        See also: <Link href="/terms" className="text-accent underline">Terms of Service</Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/(legal)/terms/page.js
+++ b/src/app/(legal)/terms/page.js
@@ -1,0 +1,290 @@
+// Terms of Service — Arcora
+// Last reviewed: 2026-05-02
+//
+// Plain-English ToS for a solo-built SaaS. Covers the unusual primitives
+// for this product:
+//   - AI-generated 90-day onboarding plans (output is informational, not
+//     career advice)
+//   - Stripe-hosted billing for the Pro tier
+//   - Manager / collaborator share links
+//   - Resend transactional email
+//   - Anthropic + OpenAI as sub-processors
+//
+// Not legal advice. Rulz reviewed and signed off on the content scope.
+
+import Link from "next/link";
+
+export const metadata = {
+  title: "Terms of Service · Arcora",
+  description:
+    "Terms governing access to and use of Arcora — the AI-powered 90-day onboarding workspace.",
+  alternates: { canonical: "/terms" },
+};
+
+const SECTIONS = [
+  { id: "agreement", label: "Your agreement with Arcora" },
+  { id: "eligibility", label: "Eligibility" },
+  { id: "account", label: "Your account" },
+  { id: "service", label: "What Arcora is — and isn't" },
+  { id: "ai-output", label: "AI-generated content" },
+  { id: "your-content", label: "Your content" },
+  { id: "sharing", label: "Sharing with managers" },
+  { id: "billing", label: "Subscriptions, trials, and refunds" },
+  { id: "acceptable-use", label: "Acceptable use" },
+  { id: "ip", label: "Intellectual property" },
+  { id: "termination", label: "Termination" },
+  { id: "warranty", label: "No warranties" },
+  { id: "liability", label: "Limitation of liability" },
+  { id: "law", label: "Governing law" },
+  { id: "changes", label: "Changes to these terms" },
+  { id: "contact", label: "Contact" },
+];
+
+const containerCls = "mb-6 leading-relaxed";
+const headingCls = "scroll-mt-20 mt-10 mb-3 font-instrument-serif text-2xl";
+const bodyCls = "text-[#1C1917] dark:text-[#E7E5E4]";
+
+function H2({ id, children }) {
+  return (
+    <h2 id={id} className={headingCls}>
+      {children}
+    </h2>
+  );
+}
+function P({ children }) {
+  return <p className={`${containerCls} ${bodyCls}`}>{children}</p>;
+}
+function UL({ children }) {
+  return <ul className="list-disc pl-6 mb-6 space-y-1.5">{children}</ul>;
+}
+
+export default function TermsPage() {
+  return (
+    <div className="font-space-grotesk text-[15px]">
+      <h1 className="font-instrument-serif text-4xl sm:text-5xl mb-3">
+        Terms of Service
+      </h1>
+      <p className="text-sm text-[#57534E] dark:text-[#A8A29E] mb-8">
+        Last updated: 2 May 2026
+      </p>
+
+      <P>
+        These terms (the &ldquo;<strong>Terms</strong>&rdquo;) govern your
+        access to and use of <strong>Arcora</strong> (the &ldquo;
+        <strong>Service</strong>&rdquo;), provided by{" "}
+        <strong>Rulz &amp; Co</strong> (&ldquo;<strong>we</strong>&rdquo;,
+        &ldquo;<strong>us</strong>&rdquo;), based in Manchester, United
+        Kingdom. By creating an account, you agree to these Terms. If you
+        don&apos;t agree, please don&apos;t use the Service.
+      </P>
+
+      <nav
+        aria-label="On this page"
+        className="border border-[#D1CDC7] dark:border-[#2C2825] rounded-xl p-4 mb-10 bg-white/60 dark:bg-[#1C1917]/60"
+      >
+        <p className="text-xs uppercase tracking-wider text-[#78716C] mb-2">
+          On this page
+        </p>
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-sm">
+          {SECTIONS.map((s) => (
+            <li key={s.id}>
+              <a
+                href={`#${s.id}`}
+                className="text-[#57534E] dark:text-[#A8A29E] hover:text-accent transition-colors"
+              >
+                {s.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <H2 id="agreement">1. Your agreement with Arcora</H2>
+      <P>
+        These Terms form a legal agreement between you and Rulz &amp; Co.
+        We may also publish supplemental terms for specific features (for
+        example, beta features). Where supplemental terms apply, they are
+        in addition to these Terms and will say so.
+      </P>
+
+      <H2 id="eligibility">2. Eligibility</H2>
+      <P>You must be at least 18 years old to use Arcora. By using the Service you confirm you meet this requirement and have the legal capacity to enter these Terms.</P>
+
+      <H2 id="account">3. Your account</H2>
+      <P>To use most of Arcora, you create an account with an email and password.</P>
+      <UL>
+        <li>You are responsible for keeping your password secure.</li>
+        <li>You are responsible for activity under your account.</li>
+        <li>Tell us promptly at <a href="mailto:legal@usearcora.com" className="text-accent underline">legal@usearcora.com</a> if you believe your account has been compromised.</li>
+        <li>One person per account. Don&apos;t share login credentials.</li>
+      </UL>
+
+      <H2 id="service">4. What Arcora is — and isn&apos;t</H2>
+      <P>
+        Arcora is a workspace that helps people who are starting a new job
+        plan and track their first 90 days. We provide AI-generated 30/60/90 plans, a stakeholder map, knowledge tools, and shared review with managers.
+      </P>
+      <P>
+        <strong>Arcora is not</strong>: legal advice, HR advice, recruitment
+        services, employment counselling, or a substitute for your
+        manager. We don&apos;t guarantee any career outcome, role
+        progression, or job retention.
+      </P>
+
+      <H2 id="ai-output">5. AI-generated content</H2>
+      <P>
+        Plans, milestones, suggested questions, and other AI-generated
+        content (&ldquo;<strong>AI Output</strong>&rdquo;) are produced by
+        third-party large language models (currently Anthropic Claude and
+        OpenAI). We tune the prompts; we don&apos;t control every word
+        generated.
+      </P>
+      <UL>
+        <li>AI Output may contain inaccuracies, omissions, or biased framing. Treat it as a starting point, not a source of truth.</li>
+        <li>You are responsible for reviewing AI Output before relying on it, sharing it with your manager, or acting on it at work.</li>
+        <li>We may change the underlying models, prompts, or generation behaviour at any time.</li>
+      </UL>
+
+      <H2 id="your-content">6. Your content</H2>
+      <P>
+        You retain ownership of the information you put into Arcora —
+        your role context, stakeholder notes, journal entries, uploaded
+        documents, and any plan content you customise (&ldquo;
+        <strong>Your Content</strong>&rdquo;).
+      </P>
+      <P>
+        You grant us a limited, worldwide, royalty-free licence to host,
+        process, transmit, and display Your Content as needed to operate
+        the Service for you. We do not sell Your Content. We do not train
+        AI models on Your Content.
+      </P>
+      <P>
+        Some Your Content may be sent to our AI sub-processors (Anthropic
+        Claude, OpenAI) to generate AI Output for you. Anthropic and
+        OpenAI process this data under their respective enterprise data
+        terms and do not train their general-purpose models on it.
+      </P>
+
+      <H2 id="sharing">7. Sharing with managers and collaborators</H2>
+      <P>
+        Arcora lets you generate share links and invite a manager or
+        teammate to view and comment on your plan. When you share, you
+        choose what to share and with whom.
+      </P>
+      <UL>
+        <li>Anyone you invite or who has a valid share link can view and comment as configured by you.</li>
+        <li>You can revoke share links and remove collaborators at any time in your settings.</li>
+        <li>You are responsible for choosing who you share Your Content with.</li>
+      </UL>
+
+      <H2 id="billing">8. Subscriptions, trials, and refunds</H2>
+      <P>
+        Arcora has a free tier and a paid <strong>Pro</strong>{" "}
+        subscription. The free tier requires no card. Pro is{" "}
+        <strong>$29 per month</strong> billed monthly, or{" "}
+        <strong>$23 per month</strong> billed annually (as displayed at
+        signup or on our pricing page).
+      </P>
+      <UL>
+        <li>Pro includes a <strong>14-day free trial</strong>. Your card is charged at the end of the trial unless you cancel.</li>
+        <li>Billing is processed by <strong>Stripe</strong>. We don&apos;t store your card details on our servers.</li>
+        <li>You can cancel at any time in your account settings. Your Pro access remains active until the end of the current billing period.</li>
+        <li>We do not provide pro-rata refunds for partial months. We may, at our discretion, offer a refund where required by law (for example, certain UK consumer rights).</li>
+        <li>Prices and feature limits may change with notice via email or in-app at least 14 days before the change takes effect.</li>
+      </UL>
+
+      <H2 id="acceptable-use">9. Acceptable use</H2>
+      <P>You agree not to:</P>
+      <UL>
+        <li>Reverse-engineer, scrape, or attempt to derive the source of the Service.</li>
+        <li>Use the Service to harass, harm, or impersonate others.</li>
+        <li>Upload content that infringes someone else&apos;s rights, including confidential information you don&apos;t have permission to share.</li>
+        <li>Send spam, bulk unsolicited messages, or fake invitations through the Service.</li>
+        <li>Probe, scan, or test the Service for vulnerabilities without our written permission.</li>
+        <li>Use the Service to build a competing product or to train AI models.</li>
+      </UL>
+      <P>We may suspend or terminate accounts that violate these rules.</P>
+
+      <H2 id="ip">10. Intellectual property</H2>
+      <P>
+        The Arcora name, logo, design, code, and content (excluding Your
+        Content and AI Output) are owned by Rulz &amp; Co or our licensors.
+        These Terms don&apos;t grant you a licence to those except as
+        needed to use the Service.
+      </P>
+
+      <H2 id="termination">11. Termination</H2>
+      <P>
+        You can stop using Arcora at any time and delete your account from
+        settings. We can suspend or terminate accounts for violation of
+        these Terms, prolonged inactivity (12+ months), or where required
+        by law.
+      </P>
+      <P>
+        On termination, your access ends and we delete or anonymise Your
+        Content within 90 days, except where retention is required for
+        legal, tax, or fraud-prevention reasons.
+      </P>
+
+      <H2 id="warranty">12. No warranties</H2>
+      <P>
+        Arcora is provided &ldquo;as is&rdquo; and &ldquo;as
+        available&rdquo;. We don&apos;t warrant that it will be
+        error-free, uninterrupted, secure, or that AI Output will be
+        accurate or fit for any particular purpose. To the fullest extent
+        permitted by law, we disclaim all implied warranties.
+      </P>
+
+      <H2 id="liability">13. Limitation of liability</H2>
+      <P>
+        To the maximum extent permitted by law, Rulz &amp; Co will not be
+        liable for indirect, incidental, special, consequential, or
+        exemplary damages, or for any loss of profits, revenue, data, use,
+        goodwill, or other intangible losses, arising out of or related to
+        your use of (or inability to use) the Service.
+      </P>
+      <P>
+        Our total liability for any claim under or relating to these Terms
+        is limited to the greater of (a) the amounts you paid us in the
+        12 months before the claim, or (b) £50.
+      </P>
+      <P>
+        Nothing in these Terms limits liability for fraud, fraudulent
+        misrepresentation, death or personal injury caused by negligence,
+        or any other liability that cannot be lawfully limited.
+      </P>
+
+      <H2 id="law">14. Governing law</H2>
+      <P>
+        These Terms are governed by the laws of England and Wales. The
+        courts of England and Wales have exclusive jurisdiction over
+        disputes, except where you have non-waivable consumer rights to
+        bring a claim in your local courts.
+      </P>
+
+      <H2 id="changes">15. Changes to these Terms</H2>
+      <P>
+        We may update these Terms. If we make material changes, we&apos;ll
+        notify you by email (to the address on your account) or in-app at
+        least 14 days before the changes take effect. Continued use after
+        changes take effect means you accept the updated Terms.
+      </P>
+
+      <H2 id="contact">16. Contact</H2>
+      <P>
+        Questions about these Terms? Email{" "}
+        <a
+          href="mailto:legal@usearcora.com"
+          className="text-accent underline"
+        >
+          legal@usearcora.com
+        </a>
+        .
+      </P>
+
+      <p className="mt-12 mb-4 text-sm text-[#78716C]">
+        See also: <Link href="/privacy" className="text-accent underline">Privacy Policy</Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -34,9 +34,56 @@ try {
 } catch (e) {}
 `;
 
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://usearcora.com";
+
 export const metadata = {
-  title: "Arcora - AI Onboarding Planner",
-  description: "Your first 90 days, engineered for impact.",
+  metadataBase: new URL(APP_URL),
+  title: {
+    default: "Arcora — Your first 90 days, engineered for impact.",
+    template: "%s · Arcora",
+  },
+  description:
+    "Generate a comprehensive, role-specific 30/60/90-day plan instantly with AI. Align with your manager and hit the ground running.",
+  applicationName: "Arcora",
+  authors: [{ name: "Rulz & Co" }],
+  creator: "Rulz & Co",
+  publisher: "Rulz & Co",
+  keywords: [
+    "90-day plan",
+    "new job",
+    "onboarding",
+    "30 60 90",
+    "manager alignment",
+    "AI career planner",
+  ],
+  openGraph: {
+    type: "website",
+    siteName: "Arcora",
+    title: "Arcora — Your first 90 days, engineered for impact.",
+    description:
+      "Generate a comprehensive, role-specific 30/60/90-day plan instantly with AI. Align with your manager and hit the ground running.",
+    url: APP_URL,
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Arcora — Your first 90 days, engineered for impact.",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Arcora — Your first 90 days, engineered for impact.",
+    description:
+      "Generate a comprehensive, role-specific 30/60/90-day plan instantly with AI.",
+    images: ["/opengraph-image"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: { index: true, follow: true, "max-image-preview": "large" },
+  },
 };
 
 export const viewport = {

--- a/src/app/opengraph-image.js
+++ b/src/app/opengraph-image.js
@@ -1,0 +1,138 @@
+import { ImageResponse } from "next/og";
+
+// Open Graph share image. Rendered at build / on demand by Next's
+// ImageResponse runtime. 1200×630 is the canonical OG dimension that
+// Twitter/X, LinkedIn, Slack, Discord, iMessage, and Mastodon all use
+// for "summary_large_image" cards.
+//
+// Pure JSX-in-JS so we don't have to host a static asset. Updates
+// automatically when we tweak the headline.
+
+export const runtime = "edge";
+export const alt = "Arcora — Your first 90 days, engineered for impact.";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "72px",
+          background:
+            "linear-gradient(135deg, #F5F2E8 0%, #FBE9DF 60%, #F5F2E8 100%)",
+          color: "#1C1917",
+          fontFamily: "system-ui, -apple-system, sans-serif",
+        }}
+      >
+        {/* Wordmark */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "14px",
+            color: "#D97757",
+            fontSize: "30px",
+            fontWeight: 700,
+            letterSpacing: "-0.5px",
+          }}
+        >
+          <div
+            style={{
+              width: "44px",
+              height: "44px",
+              borderRadius: "12px",
+              background: "#D97757",
+              color: "#FFFFFF",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: "26px",
+              fontWeight: 700,
+            }}
+          >
+            A
+          </div>
+          Arcora
+        </div>
+
+        {/* Headline */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "20px",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "72px",
+              fontWeight: 600,
+              lineHeight: 1.05,
+              letterSpacing: "-1.5px",
+              color: "#1C1917",
+              maxWidth: "950px",
+            }}
+          >
+            Your first 90 days, engineered for impact.
+          </div>
+          <div
+            style={{
+              fontSize: "30px",
+              color: "#57534E",
+              maxWidth: "900px",
+              lineHeight: 1.35,
+            }}
+          >
+            Generate a role-specific 30/60/90-day plan with AI. Align with
+            your manager. Hit the ground running.
+          </div>
+        </div>
+
+        {/* Phase chips at the bottom */}
+        <div
+          style={{
+            display: "flex",
+            gap: "12px",
+          }}
+        >
+          {[
+            { label: "Days 1–30", phase: "Learn" },
+            { label: "Days 31–60", phase: "Contribute" },
+            { label: "Days 61–90", phase: "Lead" },
+          ].map((p) => (
+            <div
+              key={p.label}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "6px",
+                padding: "16px 22px",
+                borderRadius: "12px",
+                background: "#FFFFFF",
+                border: "1px solid #E7E5E4",
+              }}
+            >
+              <div style={{ fontSize: "16px", color: "#A8A29E" }}>{p.label}</div>
+              <div
+                style={{
+                  fontSize: "26px",
+                  fontWeight: 600,
+                  color: "#1C1917",
+                }}
+              >
+                {p.phase}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/src/components/ui/Footer.js
+++ b/src/components/ui/Footer.js
@@ -57,12 +57,12 @@ export function Footer() {
             </h4>
             <ul className="space-y-2 text-xs text-[#A8A29E] font-medium">
               <li>
-                <Link href="#" className="hover:text-accent transition-colors font-space-grotesk inline-block py-1">
+                <Link href="/privacy" className="hover:text-accent transition-colors font-space-grotesk inline-block py-1">
                   Privacy
                 </Link>
               </li>
               <li>
-                <Link href="#" className="hover:text-accent transition-colors font-space-grotesk inline-block py-1">
+                <Link href="/terms" className="hover:text-accent transition-colors font-space-grotesk inline-block py-1">
                   Terms
                 </Link>
               </li>
@@ -71,7 +71,7 @@ export function Footer() {
         </div>
         <div className="flex flex-col-reverse sm:flex-row sm:items-center sm:justify-between gap-4 pt-6 sm:pt-8 border-t border-[#292524] dark:border-[#2C2825]">
           <p className="text-xs font-medium font-space-grotesk text-[#78716C]">
-            © 2026 Arcora. All rights reserved.
+            © 2026 Rulz &amp; Co. All rights reserved.
           </p>
           <div className="flex gap-5 text-[#A8A29E]">
             <a href="#" className="hover:text-accent transition-colors p-1" aria-label="Twitter">


### PR DESCRIPTION
## Why

Three launch blockers, all in one PR.

## 1. Terms of Service — `/terms`

Plain-English ToS for solo-built SaaS. Covers AI-generated content, your-content licensing, manager sharing, Stripe-hosted billing (free + Pro $29/mo or $23/mo annual, 14-day trial), acceptable use, and English-law dispute resolution. Liability cap: greater of 12 months of fees paid OR £50.

## 2. Privacy Policy — `/privacy`

UK-GDPR + EU-GDPR friendly. Lists every concrete sub-processor wired into the codebase (Convex, Vercel, Stripe, Resend, Anthropic, OpenAI, Upstash, Beehiiv) with links. Explicit no-AI-training-on-your-data, retention timeline, full rights flow (access / rectify / erase / portability / ICO complaint).

## 3. Open Graph share image — `/opengraph-image`

Edge-runtime dynamic image at 1200×630. Cream-to-peach gradient, Arcora wordmark with the 'A' logo mark, headline, and three Days-1-30 / 31-60 / 61-90 phase chips. No static asset to host.

## Also

- Footer 'Privacy' and 'Terms' links now point at the real pages (were `href="#"` placeholders)
- Footer copyright: 'Arcora' → 'Rulz & Co'
- Root metadata: title template, description, OG / Twitter card config, robots hints, metadataBase from `NEXT_PUBLIC_APP_URL`

## Verification

- pnpm lint clean
- pnpm build clean
- /terms + /privacy prerender static
- /opengraph-image runs on Edge

## Heads up — legal scope

Per Rulz's confirmation, legal entity is 'Rulz & Co' in Manchester, UK with no company number or registered address. Acceptable for soft launch. Worth upgrading to a virtual office (Hoxton Mix etc, ~£10-20/mo) before heavy EU marketing — UK GDPR Art 13(1)(a)-(b) implies a contact address.

🦀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated Terms of Service and Privacy Policy pages with section navigation.
  * Added custom Open Graph image for enhanced social media sharing.

* **Updates**
  * Updated footer links to point to Terms and Privacy pages.
  * Updated website branding messaging and copyright attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->