### PR TITLE
fix(public-share): goals field is targetPhase, not phaseNumber

### DIFF
--- a/convex/publicPlans.js
+++ b/convex/publicPlans.js
@@ -270,7 +270,11 @@ export const getByPublicSlug = query({
       goals: goals
         .map((g) => ({
           title: g.title,
-          phaseNumber: g.phaseNumber ?? g.phase ?? null,
+          // Schema field is `targetPhase` (1–3). Earlier fallbacks for
+          // `phaseNumber` / `phase` covered older data shapes; keep them
+          // for safety but the real field is `targetPhase`.
+          phaseNumber:
+            g.targetPhase ?? g.phaseNumber ?? g.phase ?? null,
           category: g.category ?? null,
         }))
         .filter((g) => g.phaseNumber !== null),


### PR DESCRIPTION
Live retest after #45 / Convex deploy fix surfaced one more bug: `/p/{slug}` showed 'No goals in this phase' for all 3 phases.

**Root cause:** `getByPublicSlug` mapped goals by `g.phaseNumber` / `g.phase`, but the real schema field is `targetPhase`.

**Fix:** Try `targetPhase` first, then fall back to `phaseNumber` / `phase` for safety on older or differently-shaped rows.

pnpm lint clean. After this deploys, the public page will render goals correctly.

🦀