### PR TITLE
fix(email): default APP_URL fallback to usearcora.com, not app subdomain

### DIFF
--- a/convex/ResendOTP.js
+++ b/convex/ResendOTP.js
@@ -9,7 +9,11 @@ import { renderEmailShell, renderCodeBlock, BRAND } from "./lib/emailLayout";
 // complete the flow by copying the code from the server log.
 
 const FROM_ADDRESS = process.env.AUTH_EMAIL ?? "Arcora <hello@switchtoux.com>";
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.usearcora.com";
+// Default to the root marketing/app domain. We're not running a separate
+// app subdomain (app.usearcora.com is intentionally unconfigured), so a
+// fallback to that subdomain produced 404s on every email CTA when the
+// NEXT_PUBLIC_APP_URL env wasn't set on Convex prod.
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://usearcora.com";
 const PRODUCT_NAME = process.env.PRODUCT_NAME ?? "Arcora";
 const LOGO_URL = process.env.EMAIL_LOGO_URL ?? "";
 

--- a/convex/ResendOTPPasswordReset.js
+++ b/convex/ResendOTPPasswordReset.js
@@ -8,7 +8,8 @@ import { renderEmailShell, renderCodeBlock, BRAND } from "./lib/emailLayout";
 // `flow: "reset-verification"`.
 
 const FROM_ADDRESS = process.env.AUTH_EMAIL ?? "Arcora <hello@switchtoux.com>";
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.usearcora.com";
+// Default to the root marketing/app domain. See ResendOTP.js for context.
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://usearcora.com";
 const PRODUCT_NAME = process.env.PRODUCT_NAME ?? "Arcora";
 const LOGO_URL = process.env.EMAIL_LOGO_URL ?? "";
 

--- a/convex/emailActions.js
+++ b/convex/emailActions.js
@@ -22,7 +22,11 @@ const FROM_ADDRESS =
   process.env.AUTH_EMAIL ??
   "Arcora <hello@switchtoux.com>";
 
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.usearcora.com";
+// Default to the root marketing/app domain. We don't have a separate
+// app subdomain wired up; emailing CTAs that pointed to
+// app.usearcora.com 404'd in production whenever the NEXT_PUBLIC_APP_URL
+// env var wasn't set on Convex.
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://usearcora.com";
 const PRODUCT_NAME = process.env.PRODUCT_NAME ?? "Arcora";
 const LOGO_URL = process.env.EMAIL_LOGO_URL ?? "";
 

--- a/convex/emailChangeActions.js
+++ b/convex/emailChangeActions.js
@@ -6,7 +6,8 @@ import { Resend } from "resend";
 import { renderEmailShell, renderCodeBlock, BRAND } from "./lib/emailLayout";
 
 const FROM_ADDRESS = process.env.AUTH_EMAIL ?? "Arcora <hello@switchtoux.com>";
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.usearcora.com";
+// Default to the root marketing/app domain. See ResendOTP.js for context.
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://usearcora.com";
 const PRODUCT_NAME = process.env.PRODUCT_NAME ?? "Arcora";
 const LOGO_URL = process.env.EMAIL_LOGO_URL ?? "";
 


### PR DESCRIPTION
## Bug

Live retest on iPhone: clicked CTA in the manager-invite email → Vercel `404 NOT_FOUND / DEPLOYMENT_NOT_FOUND` page.

## Root cause

Every Convex email module defaulted `APP_URL` to `https://app.usearcora.com`, but we don't run a separate app subdomain. Whenever `NEXT_PUBLIC_APP_URL` wasn't set on Convex prod env, every email CTA pointed to a non-existent deployment.

## Fix

Switched the fallback to `https://usearcora.com` (the actual deployment) across all four Convex email modules:

- `convex/ResendOTP.js`
- `convex/ResendOTPPasswordReset.js`
- `convex/emailChangeActions.js`
- `convex/emailActions.js`

Next.js side (sitemap, layout, robots) already used the correct fallback.

When you do eventually split marketing + app, set `NEXT_PUBLIC_APP_URL` on Convex prod to the new subdomain — it wins over the fallback. The fallback just stops being a footgun.

## Verification

- pnpm lint clean
- After Convex deploys via CI, every email CTA goes back to a working URL.

🦀