### PR TITLE
fix(tasks): rescheduled tasks now appear on Today's Plan

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -45,6 +45,7 @@ import type * as lib_rateLimit from "../lib/rateLimit.js";
 import type * as lib_stakeholderCadence from "../lib/stakeholderCadence.js";
 import type * as logEntries from "../logEntries.js";
 import type * as loginAttempts from "../loginAttempts.js";
+import type * as migrations_clearRescheduledStatus from "../migrations/clearRescheduledStatus.js";
 import type * as migrations_grandfather from "../migrations/grandfather.js";
 import type * as migrations_legacyKnowledgeToDocuments from "../migrations/legacyKnowledgeToDocuments.js";
 import type * as migrations_pilotKbSeed from "../migrations/pilotKbSeed.js";
@@ -108,6 +109,7 @@ declare const fullApi: ApiFromModules<{
   "lib/stakeholderCadence": typeof lib_stakeholderCadence;
   logEntries: typeof logEntries;
   loginAttempts: typeof loginAttempts;
+  "migrations/clearRescheduledStatus": typeof migrations_clearRescheduledStatus;
   "migrations/grandfather": typeof migrations_grandfather;
   "migrations/legacyKnowledgeToDocuments": typeof migrations_legacyKnowledgeToDocuments;
   "migrations/pilotKbSeed": typeof migrations_pilotKbSeed;

--- a/convex/activities.js
+++ b/convex/activities.js
@@ -136,7 +136,6 @@ export const reschedule = mutation({
     }
 
     await ctx.db.patch(args.id, {
-      status: "rescheduled",
       scheduledDate: args.newDate,
     });
   },

--- a/convex/migrations/clearRescheduledStatus.js
+++ b/convex/migrations/clearRescheduledStatus.js
@@ -1,0 +1,43 @@
+import { v } from "convex/values";
+import { internalMutation } from "../_generated/server";
+
+/**
+ * One-shot cleanup. Before the reschedule-mutation fix, rescheduling a task
+ * also flipped its status to "rescheduled" — which no view filters on, so
+ * the task vanished from Today's Plan and the Tasks "Upcoming" tab.
+ *
+ * Resets every activity stuck on `status: "rescheduled"` back to `"upcoming"`.
+ * The reschedule UI gates on !isDone && !isSkipped, so any such rows were
+ * upcoming before being rescheduled — restoring that is the correct intent.
+ *
+ *   # Preview without writing:
+ *   npx convex run migrations/clearRescheduledStatus:clearRescheduledStatus '{"dryRun": true}'
+ *
+ *   # Apply:
+ *   npx convex run migrations/clearRescheduledStatus:clearRescheduledStatus '{}'
+ *
+ * Idempotent: re-runs with zero matches return cleanly.
+ */
+export const clearRescheduledStatus = internalMutation({
+  args: { dryRun: v.optional(v.boolean()) },
+  handler: async (ctx, { dryRun }) => {
+    const preview = dryRun ?? false;
+
+    const stuck = await ctx.db
+      .query("activities")
+      .filter((q) => q.eq(q.field("status"), "rescheduled"))
+      .collect();
+
+    if (!preview) {
+      for (const activity of stuck) {
+        await ctx.db.patch(activity._id, { status: "upcoming" });
+      }
+    }
+
+    return {
+      matched: stuck.length,
+      updated: preview ? 0 : stuck.length,
+      dryRun: preview,
+    };
+  },
+});


### PR DESCRIPTION
## Summary

- Drop the `status: \"rescheduled\"` write from the reschedule mutation so rescheduled tasks stay `upcoming` and surface on Today's Plan and the Tasks → Upcoming tab.
- Add a one-shot internal mutation to reset existing rows already stuck on `status === \"rescheduled\"` back to `upcoming`.

## Why

Reproducing the bug: open a task in Tasks & Milestones, tap Reschedule, set the new date to today, Confirm. The toast says \"Activity rescheduled\" but the task never appears in `/today`.

Root cause is in [convex/activities.js](convex/activities.js):

```js
// before
await ctx.db.patch(args.id, {
  status: \"rescheduled\",
  scheduledDate: args.newDate,
});
```

`getToday` correctly returns the task (it matches on `scheduledDate`), but [src/app/(app)/today/page.js:166-167](src/app/(app)/today/page.js) splits the result into `completed` / `upcoming` buckets only — a `rescheduled` status falls into neither, so the task is silently invisible. Same pattern in [src/app/(app)/tasks/page.js:195](src/app/(app)/tasks/page.js) hides it from the Upcoming tab.

A repo-wide grep showed `status: \"rescheduled\"` was written in exactly one place and read in zero. It was effectively a write-only enum value that only existed to break filtering — so the cleanest fix is to stop writing it, rather than teach every consumer to special-case it.

## What changed

- **[convex/activities.js](convex/activities.js)** — `reschedule` mutation now patches only `scheduledDate`. Status remains whatever it was (the UI already gates reschedule on `!isDone && !isSkipped`, so this is always `upcoming` in practice).
- **[convex/migrations/clearRescheduledStatus.js](convex/migrations/clearRescheduledStatus.js)** — internal mutation that flips any leftover `status === \"rescheduled\"` rows back to `upcoming`. Supports `dryRun`. Already executed on the dev deploy (matched 1, updated 1).
- **convex/_generated/api.d.ts** — auto-regenerated from the new migration file.

## Out of scope (deliberately)

- No schema change. `status: v.string()` is free-form; nothing in the schema enforced the enum, so no migration is required for new code.
- `scheduledDay` / `weekNumber` still drift independently of `scheduledDate` on reschedule (matches the existing `update` mutation's convention). Tasks & Milestones groups by `weekNumber`, so a Week 1 task rescheduled to a Week 3 date still sits under Week 1. That's a separate design call — out of scope for this fix.

## Test plan

- [x] Static grep: `grep -rn rescheduled convex src --include='*.js'` returns only the toast string in `tasks/page.js:277`. No status writes or comparisons remain.
- [x] `npx convex dev --once` pushed cleanly to dev (`grandiose-tiger-671`).
- [x] Migration dry-run on dev → matched 1, updated 0. Applied → matched 1, updated 1. Re-run dry-run → matched 0 (idempotent).
- [ ] In `/tasks`, open an upcoming task, Reschedule → today's date → Confirm. Verify it appears in `/today` under Today's progress with checkbox/skip/reschedule controls.
- [ ] In `/tasks` Upcoming tab, verify the rescheduled task is listed (no longer hidden).
- [ ] Complete the task from `/today` — verify it moves to the completed section.

## Migration runbook (prod)

After merge, run once on the prod deploy:

```
npx convex run migrations/clearRescheduledStatus:clearRescheduledStatus '{\"dryRun\": true}'
npx convex run migrations/clearRescheduledStatus:clearRescheduledStatus '{}'
```

Idempotent — safe to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rescheduled activities now preserve their original status instead of being marked as "rescheduled."

* **Chores**
  * Added data cleanup process to reset activities with legacy status markers to their correct state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jeberulz/first90days/pull/52)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->